### PR TITLE
#4/see client list

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,21 @@ mix run priv/repo/seeds.exs
 dropdb focal_api_test
 mix ecto.migrate
 ```
+#### Deploying to Heroku from CLI
+```
+git push heroku <branch_name>:master
+```
+
+## Setting up Environment Variables + Starting Local Server
+-  Create a .env file in your root and add the following
+```
+export GOOGLE_CLIENT_ID="Get from Teammate"
+export GOOGLE_CLIENT_SECRET="Get from Teammate"
+export CLIENT_HOST=http://localhost:<client_port>
+```
+- `source .env`
+- `mix phx.server`
+
+## Running Tests
+- `source .env`
+- `mix test`

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ mix ecto.rollback
 mix ecto.migrate
 mix run priv/repo/seeds.exs
 ```
+
+#### Resetting the Test Database after a schema change
+```
+dropdb focal_api_test
+mix ecto.migrate
+```

--- a/lib/focal_api/accounts.ex
+++ b/lib/focal_api/accounts.ex
@@ -39,6 +39,8 @@ defmodule FocalApi.Accounts do
 
   def get_user_by_uuid!(uuid), do: Repo.get_by!(User, uuid: uuid)
 
+  def get_user_by_email(email), do: Repo.get_by(User, email: email)
+
   @doc """
   Creates a user.
 

--- a/lib/focal_api/clients.ex
+++ b/lib/focal_api/clients.ex
@@ -126,6 +126,12 @@ defmodule FocalApi.Clients do
     Repo.all(Package)
   end
 
+  def list_packages_by_client(client_uuid) do
+    client = get_client_by_uuid!(client_uuid)
+    query = from package in Package, where: ^client.id == package.client_id
+    Repo.all(query, preload: [:client])
+  end
+
   @doc """
   Gets a single package.
 

--- a/lib/focal_api/clients.ex
+++ b/lib/focal_api/clients.ex
@@ -110,4 +110,102 @@ defmodule FocalApi.Clients do
   def change_client(%Client{} = client) do
     Client.changeset(client, %{})
   end
+
+  alias FocalApi.Clients.Package
+
+  @doc """
+  Returns the list of packages.
+
+  ## Examples
+
+      iex> list_packages()
+      [%Package{}, ...]
+
+  """
+  def list_packages do
+    Repo.all(Package)
+  end
+
+  @doc """
+  Gets a single package.
+
+  Raises `Ecto.NoResultsError` if the Package does not exist.
+
+  ## Examples
+
+      iex> get_package!(123)
+      %Package{}
+
+      iex> get_package!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_package!(id), do: Repo.get!(Package, id)
+
+  def get_package_by_uuid!(uuid), do: Repo.get_by!(Package, uuid: uuid)
+
+  @doc """
+  Creates a package.
+
+  ## Examples
+
+      iex> create_package(%{field: value})
+      {:ok, %Package{}}
+
+      iex> create_package(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_package(attrs \\ %{}) do
+    %Package{}
+    |> Package.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a package.
+
+  ## Examples
+
+      iex> update_package(package, %{field: new_value})
+      {:ok, %Package{}}
+
+      iex> update_package(package, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_package(%Package{} = package, attrs) do
+    package
+    |> Package.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Package.
+
+  ## Examples
+
+      iex> delete_package(package)
+      {:ok, %Package{}}
+
+      iex> delete_package(package)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_package(%Package{} = package) do
+    Repo.delete(package)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking package changes.
+
+  ## Examples
+
+      iex> change_package(package)
+      %Ecto.Changeset{source: %Package{}}
+
+  """
+  def change_package(%Package{} = package) do
+    Package.changeset(package, %{})
+  end
 end

--- a/lib/focal_api/clients.ex
+++ b/lib/focal_api/clients.ex
@@ -136,6 +136,15 @@ defmodule FocalApi.Clients do
     Repo.all(query, preload: [:client])
   end
 
+  def list_first_uncompleted_task_by_client(client_uuid) do
+    client = get_client_by_uuid!(client_uuid)
+    query = from task in Task,
+              where: ^client.id == task.client_id and task.is_completed == false,
+              order_by: task.inserted_at,
+              limit: 1
+    Repo.all(query, preload: [:client])
+  end
+
   def get_task!(id), do: Repo.get!(Task, id)
 
   def get_task_by_uuid!(uuid), do: Repo.get_by!(Task, uuid: uuid)

--- a/lib/focal_api/clients.ex
+++ b/lib/focal_api/clients.ex
@@ -214,4 +214,108 @@ defmodule FocalApi.Clients do
   def change_package(%Package{} = package) do
     Package.changeset(package, %{})
   end
+
+  alias FocalApi.Clients.Event
+
+  @doc """
+  Returns the list of events.
+
+  ## Examples
+
+      iex> list_events()
+      [%Event{}, ...]
+
+  """
+  def list_events do
+    Repo.all(Event)
+  end
+
+  def list_events_by_package(package_uuid) do
+    package = get_package_by_uuid!(package_uuid)
+    query = from event in Event, where: ^package.id == event.package_id
+    Repo.all(query, preload: [:package])
+  end
+
+  @doc """
+  Gets a single event.
+
+  Raises `Ecto.NoResultsError` if the Event does not exist.
+
+  ## Examples
+
+      iex> get_event!(123)
+      %Event{}
+
+      iex> get_event!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_event!(id), do: Repo.get!(Event, id)
+
+  def get_event_by_uuid!(uuid), do: Repo.get_by!(Event, uuid: uuid)
+
+  @doc """
+  Creates a event.
+
+  ## Examples
+
+      iex> create_event(%{field: value})
+      {:ok, %Event{}}
+
+      iex> create_event(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_event(attrs \\ %{}) do
+    %Event{}
+    |> Event.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a event.
+
+  ## Examples
+
+      iex> update_event(event, %{field: new_value})
+      {:ok, %Event{}}
+
+      iex> update_event(event, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_event(%Event{} = event, attrs) do
+    event
+    |> Event.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Event.
+
+  ## Examples
+
+      iex> delete_event(event)
+      {:ok, %Event{}}
+
+      iex> delete_event(event)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_event(%Event{} = event) do
+    Repo.delete(event)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking event changes.
+
+  ## Examples
+
+      iex> change_event(event)
+      %Ecto.Changeset{source: %Event{}}
+
+  """
+  def change_event(%Event{} = event) do
+    Event.changeset(event, %{})
+  end
 end

--- a/lib/focal_api/clients.ex
+++ b/lib/focal_api/clients.ex
@@ -1,23 +1,9 @@
 defmodule FocalApi.Clients do
-  @moduledoc """
-  The Clients context.
-  """
-
   import Ecto.Query, warn: false
   alias FocalApi.Repo
-
   alias FocalApi.Clients.Client
   alias FocalApi.Accounts
 
-  @doc """
-  Returns the list of clients.
-
-  ## Examples
-
-      iex> list_clients()
-      [%Client{}, ...]
-
-  """
   def list_clients do
     Repo.all(Client)
   end
@@ -28,100 +14,32 @@ defmodule FocalApi.Clients do
     Repo.all(query, preload: [:user])
   end
 
-  @doc """
-  Gets a single client.
-
-  Raises `Ecto.NoResultsError` if the Client does not exist.
-
-  ## Examples
-
-      iex> get_client!(123)
-      %Client{}
-
-      iex> get_client!(456)
-      ** (Ecto.NoResultsError)
-
-  """
   def get_client!(id), do: Repo.get!(Client, id)
 
   def get_client_by_uuid!(uuid), do: Repo.get_by!(Client, uuid: uuid)
 
-  @doc """
-  Creates a client.
-
-  ## Examples
-
-      iex> create_client(%{field: value})
-      {:ok, %Client{}}
-
-      iex> create_client(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
   def create_client(attrs \\ %{}) do
     %Client{}
     |> Client.changeset(attrs)
     |> Repo.insert()
   end
 
-  @doc """
-  Updates a client.
-
-  ## Examples
-
-      iex> update_client(client, %{field: new_value})
-      {:ok, %Client{}}
-
-      iex> update_client(client, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
   def update_client(%Client{} = client, attrs) do
     client
     |> Client.changeset(attrs)
     |> Repo.update()
   end
 
-  @doc """
-  Deletes a Client.
-
-  ## Examples
-
-      iex> delete_client(client)
-      {:ok, %Client{}}
-
-      iex> delete_client(client)
-      {:error, %Ecto.Changeset{}}
-
-  """
   def delete_client(%Client{} = client) do
     Repo.delete(client)
   end
 
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking client changes.
-
-  ## Examples
-
-      iex> change_client(client)
-      %Ecto.Changeset{source: %Client{}}
-
-  """
   def change_client(%Client{} = client) do
     Client.changeset(client, %{})
   end
 
   alias FocalApi.Clients.Package
 
-  @doc """
-  Returns the list of packages.
-
-  ## Examples
-
-      iex> list_packages()
-      [%Package{}, ...]
-
-  """
   def list_packages do
     Repo.all(Package)
   end
@@ -132,100 +50,32 @@ defmodule FocalApi.Clients do
     Repo.all(query, preload: [:client])
   end
 
-  @doc """
-  Gets a single package.
-
-  Raises `Ecto.NoResultsError` if the Package does not exist.
-
-  ## Examples
-
-      iex> get_package!(123)
-      %Package{}
-
-      iex> get_package!(456)
-      ** (Ecto.NoResultsError)
-
-  """
   def get_package!(id), do: Repo.get!(Package, id)
 
   def get_package_by_uuid!(uuid), do: Repo.get_by!(Package, uuid: uuid)
 
-  @doc """
-  Creates a package.
-
-  ## Examples
-
-      iex> create_package(%{field: value})
-      {:ok, %Package{}}
-
-      iex> create_package(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
   def create_package(attrs \\ %{}) do
     %Package{}
     |> Package.changeset(attrs)
     |> Repo.insert()
   end
 
-  @doc """
-  Updates a package.
-
-  ## Examples
-
-      iex> update_package(package, %{field: new_value})
-      {:ok, %Package{}}
-
-      iex> update_package(package, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
   def update_package(%Package{} = package, attrs) do
     package
     |> Package.changeset(attrs)
     |> Repo.update()
   end
 
-  @doc """
-  Deletes a Package.
-
-  ## Examples
-
-      iex> delete_package(package)
-      {:ok, %Package{}}
-
-      iex> delete_package(package)
-      {:error, %Ecto.Changeset{}}
-
-  """
   def delete_package(%Package{} = package) do
     Repo.delete(package)
   end
 
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking package changes.
-
-  ## Examples
-
-      iex> change_package(package)
-      %Ecto.Changeset{source: %Package{}}
-
-  """
   def change_package(%Package{} = package) do
     Package.changeset(package, %{})
   end
 
   alias FocalApi.Clients.Event
 
-  @doc """
-  Returns the list of events.
-
-  ## Examples
-
-      iex> list_events()
-      [%Event{}, ...]
-
-  """
   def list_events do
     Repo.all(Event)
   end
@@ -236,86 +86,77 @@ defmodule FocalApi.Clients do
     Repo.all(query, preload: [:package])
   end
 
-  @doc """
-  Gets a single event.
-
-  Raises `Ecto.NoResultsError` if the Event does not exist.
-
-  ## Examples
-
-      iex> get_event!(123)
-      %Event{}
-
-      iex> get_event!(456)
-      ** (Ecto.NoResultsError)
-
-  """
   def get_event!(id), do: Repo.get!(Event, id)
 
   def get_event_by_uuid!(uuid), do: Repo.get_by!(Event, uuid: uuid)
 
-  @doc """
-  Creates a event.
+  def get_event_by_uuid(event_uuid) do
+    event_uuid
+    |> gracefully_handle_get
+  end
 
-  ## Examples
+  defp gracefully_handle_get(nil), do: nil
+  defp gracefully_handle_get(event_uuid), do: Repo.get_by(Event, uuid: event_uuid)
 
-      iex> create_event(%{field: value})
-      {:ok, %Event{}}
-
-      iex> create_event(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
   def create_event(attrs \\ %{}) do
     %Event{}
     |> Event.changeset(attrs)
     |> Repo.insert()
   end
 
-  @doc """
-  Updates a event.
-
-  ## Examples
-
-      iex> update_event(event, %{field: new_value})
-      {:ok, %Event{}}
-
-      iex> update_event(event, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
   def update_event(%Event{} = event, attrs) do
     event
     |> Event.changeset(attrs)
     |> Repo.update()
   end
 
-  @doc """
-  Deletes a Event.
-
-  ## Examples
-
-      iex> delete_event(event)
-      {:ok, %Event{}}
-
-      iex> delete_event(event)
-      {:error, %Ecto.Changeset{}}
-
-  """
   def delete_event(%Event{} = event) do
     Repo.delete(event)
   end
 
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking event changes.
-
-  ## Examples
-
-      iex> change_event(event)
-      %Ecto.Changeset{source: %Event{}}
-
-  """
   def change_event(%Event{} = event) do
     Event.changeset(event, %{})
+  end
+
+  alias FocalApi.Clients.Task
+
+  def list_tasks do
+    Repo.all(Task)
+  end
+
+  def list_tasks_by_event(event_uuid) do
+    event = get_event_by_uuid!(event_uuid)
+    query = from task in Task, where: ^event.id == task.event_id
+    Repo.all(query, preload: [:event])
+  end
+
+  def list_tasks_by_client(client_uuid) do
+    client = get_client_by_uuid!(client_uuid)
+    query = from task in Task, where: ^client.id == task.client_id
+    Repo.all(query, preload: [:client])
+  end
+
+  def get_task!(id), do: Repo.get!(Task, id)
+
+  def get_task_by_uuid!(uuid), do: Repo.get_by!(Task, uuid: uuid)
+
+  def create_task(attrs \\ %{}) do
+    %Task{}
+    |> Task.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_task(%Task{} = task, attrs) do
+    task
+    |> Task.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def delete_task(%Task{} = task) do
+    Repo.delete(task)
+  end
+
+  def change_task(%Task{} = task) do
+    Task.changeset(task, %{})
   end
 end

--- a/lib/focal_api/clients.ex
+++ b/lib/focal_api/clients.ex
@@ -88,6 +88,14 @@ defmodule FocalApi.Clients do
 
   def get_event!(id), do: Repo.get!(Event, id)
 
+  def get_event(id) do
+    id
+    |> gracefully_handle_id_get
+  end
+
+  defp gracefully_handle_id_get(nil), do: nil
+  defp gracefully_handle_id_get(id), do: Repo.get_by(Event, id: id)
+
   def get_event_by_uuid!(uuid), do: Repo.get_by!(Event, uuid: uuid)
 
   def get_event_by_uuid(event_uuid) do

--- a/lib/focal_api/clients/client.ex
+++ b/lib/focal_api/clients/client.ex
@@ -2,11 +2,15 @@ defmodule FocalApi.Clients.Client do
   use Ecto.Schema
   import Ecto.Changeset
   alias FocalApi.Accounts.User
+  alias FocalApi.Clients.Package
+  alias FocalApi.Clients.Event
 
   schema "clients" do
     field :client_name, :string
     field :uuid, Ecto.UUID
     belongs_to :user, User
+    has_many :packages, Package
+    has_many :events, Event
 
     timestamps()
   end

--- a/lib/focal_api/clients/event.ex
+++ b/lib/focal_api/clients/event.ex
@@ -1,0 +1,24 @@
+defmodule FocalApi.Clients.Event do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias FocalApi.Clients.Package
+  alias FocalApi.Clients.Client
+
+  schema "events" do
+    field :event_name, :string
+    field :shoot_date, :utc_datetime
+    field :uuid, Ecto.UUID
+    belongs_to :client, Client
+    belongs_to :package, Package
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(event, attrs) do
+    event
+    |> cast(attrs, [:event_name, :shoot_date, :uuid, :client_id, :package_id])
+    |> validate_required([:event_name, :shoot_date, :uuid])
+  end
+end

--- a/lib/focal_api/clients/package.ex
+++ b/lib/focal_api/clients/package.ex
@@ -1,0 +1,20 @@
+defmodule FocalApi.Clients.Package do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias FocalApi.Clients.Client
+
+  schema "packages" do
+    field :package_name, :string
+    field :uuid, Ecto.UUID
+    belongs_to :client, Client
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(package, attrs) do
+    package
+    |> cast(attrs, [:package_name, :uuid, :client_id])
+    |> validate_required([:package_name, :uuid])
+  end
+end

--- a/lib/focal_api/clients/task.ex
+++ b/lib/focal_api/clients/task.ex
@@ -1,0 +1,24 @@
+defmodule FocalApi.Clients.Task do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias FocalApi.Clients.Client
+  alias FocalApi.Clients.Event
+
+  schema "tasks" do
+    field :category, :string
+    field :is_completed, :boolean, default: false
+    field :step, :string
+    field :uuid, Ecto.UUID
+    belongs_to :event, Event
+    belongs_to :client, Client
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(task, attrs) do
+    task
+    |> cast(attrs, [:uuid, :category, :step, :is_completed, :event_id, :client_id])
+    |> validate_required([:uuid, :category, :step, :is_completed])
+  end
+end

--- a/lib/focal_api_web/controllers/client_controller.ex
+++ b/lib/focal_api_web/controllers/client_controller.ex
@@ -15,6 +15,11 @@ defmodule FocalApiWeb.ClientController do
     render(conn, "index.json", clients: clients)
   end
 
+  def index_of_all_client_data_by_user(conn, %{"user_uuid" => user_uuid}) do
+    clients = Clients.list_clients_by_user(user_uuid)
+    render(conn, "index_of_all_client_data.json", clients: clients)
+  end
+
   def create(conn, params) do
     current_user = conn.assigns[:user]
 

--- a/lib/focal_api_web/controllers/client_controller.ex
+++ b/lib/focal_api_web/controllers/client_controller.ex
@@ -6,8 +6,8 @@ defmodule FocalApiWeb.ClientController do
 
   action_fallback FocalApiWeb.FallbackController
 
-  plug FocalApiWeb.Plugs.AuthenticateSession when action in [:create, :update, :delete, :index_by_user, :show]
-  plug FocalApiWeb.Plugs.AuthorizeUserByClientUUID when action in [:update, :delete, :show]
+  plug FocalApiWeb.Plugs.AuthenticateSession when action in [:create, :update, :delete, :index_by_user, :show, :show_all_client_data]
+  plug FocalApiWeb.Plugs.AuthorizeUserByClientUUID when action in [:update, :delete, :show, :show_all_client_data]
   plug :authorize_user_by_user_uuid when action in [:index_by_user]
 
   def index_by_user(conn, %{"user_uuid" => user_uuid}) do
@@ -33,6 +33,11 @@ defmodule FocalApiWeb.ClientController do
   def show(conn, %{"client_uuid" => client_uuid}) do
     client = Clients.get_client_by_uuid!(client_uuid)
     render(conn, "show.json", client: client)
+  end
+
+  def show_all_client_data(conn, %{"client_uuid" => client_uuid}) do
+    client = Clients.get_client_by_uuid!(client_uuid)
+    render(conn, "show_all_client_data.json", client: client)
   end
 
   def update(conn, params) do

--- a/lib/focal_api_web/controllers/event_controller.ex
+++ b/lib/focal_api_web/controllers/event_controller.ex
@@ -4,8 +4,13 @@ defmodule FocalApiWeb.EventController do
   alias FocalApi.Clients
   alias FocalApi.Clients.Event
   alias FocalApi.Repo
+  alias FocalApi.Accounts
 
   action_fallback FocalApiWeb.FallbackController
+
+  plug FocalApiWeb.Plugs.AuthenticateSession when action in [:create, :update, :delete, :index_by_package, :show]
+  plug FocalApiWeb.Plugs.AuthorizeUserByPackageUUID when action in [:index_by_package, :create]
+  plug :authorize_user_by_event_uuid when action in [:update, :delete, :show]
 
   def index_by_package(conn, %{"package_uuid" => package_uuid}) do
     events = Clients.list_events_by_package(package_uuid)
@@ -51,6 +56,26 @@ defmodule FocalApiWeb.EventController do
 
     with {:ok, %Event{}} <- Clients.delete_event(event) do
       send_resp(conn, :no_content, "")
+    end
+  end
+
+  defp authorize_user_by_event_uuid(conn, _params) do
+    event = conn.params["event_uuid"]
+    |> Clients.get_event_by_uuid!
+    |> Repo.preload(:client)
+
+    events_user = Accounts.get_user!(event.client.user_id)
+
+    current_user = conn.assigns[:user]
+
+    if current_user != nil && events_user.uuid == current_user.uuid do
+      conn
+    else
+      conn
+      |> put_status(:forbidden)
+      |> put_view(FocalApiWeb.ErrorView)
+      |> render("403.json")
+      |> halt()
     end
   end
 end

--- a/lib/focal_api_web/controllers/event_controller.ex
+++ b/lib/focal_api_web/controllers/event_controller.ex
@@ -1,0 +1,56 @@
+defmodule FocalApiWeb.EventController do
+  use FocalApiWeb, :controller
+
+  alias FocalApi.Clients
+  alias FocalApi.Clients.Event
+  alias FocalApi.Repo
+
+  action_fallback FocalApiWeb.FallbackController
+
+  def index_by_package(conn, %{"package_uuid" => package_uuid}) do
+    events = Clients.list_events_by_package(package_uuid)
+    render(conn, "index.json", events: events)
+  end
+
+  def create(conn, params) do
+    package = params["package_uuid"]
+    |> Clients.get_package_by_uuid!()
+    |> Repo.preload(:client)
+
+    create_attrs = params
+    |> Map.put("client_id", package.client.id)
+    |> Map.put("package_id", package.id)
+    |> Map.put_new("uuid", Ecto.UUID.generate)
+
+    with {:ok, %Event{} = event} <- Clients.create_event(create_attrs) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.event_path(conn, :show, event))
+      |> render("show.json", event: event)
+    end
+  end
+
+  def show(conn, %{"event_uuid" => event_uuid}) do
+    event = Clients.get_event_by_uuid!(event_uuid)
+    render(conn, "show.json", event: event)
+  end
+
+  def update(conn, params) do
+    event = Clients.get_event_by_uuid!(params["event_uuid"])
+
+    update_attrs = params
+    |> Map.put("uuid", event.uuid)
+
+    with {:ok, %Event{} = event} <- Clients.update_event(event, update_attrs) do
+      render(conn, "show.json", event: event)
+    end
+  end
+
+  def delete(conn, %{"event_uuid" => event_uuid}) do
+    event = Clients.get_event_by_uuid!(event_uuid)
+
+    with {:ok, %Event{}} <- Clients.delete_event(event) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/focal_api_web/controllers/package_controller.ex
+++ b/lib/focal_api_web/controllers/package_controller.ex
@@ -3,14 +3,17 @@ defmodule FocalApiWeb.PackageController do
 
   alias FocalApi.Clients
   alias FocalApi.Clients.Package
+  alias FocalApi.Repo
+  alias FocalApi.Accounts
 
   action_fallback FocalApiWeb.FallbackController
 
-  plug FocalApiWeb.Plugs.AuthenticateSession when action in [:create, :update, :delete, :index, :show]
-  plug FocalApiWeb.Plugs.AuthorizeUserByClientUUID when action in [:create, :update, :delete, :show, :index]
+  plug FocalApiWeb.Plugs.AuthenticateSession when action in [:create, :update, :delete, :index_by_client, :show]
+  plug FocalApiWeb.Plugs.AuthorizeUserByClientUUID when action in [:create, :index_by_client]
+  plug :authorize_user_by_package_uuid when action in [:update, :delete, :show]
 
-  def index(conn, _params) do
-    packages = Clients.list_packages()
+  def index_by_client(conn, %{"client_uuid" => client_uuid}) do
+    packages = Clients.list_packages_by_client(client_uuid)
     render(conn, "index.json", packages: packages)
   end
 
@@ -24,7 +27,7 @@ defmodule FocalApiWeb.PackageController do
     with {:ok, %Package{} = package} <- Clients.create_package(create_attrs) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", Routes.package_path(conn, :show, params["client_uuid"], package.uuid))
+      |> put_resp_header("location", Routes.package_path(conn, :show, package.uuid))
       |> render("show.json", package: package)
     end
   end
@@ -50,6 +53,26 @@ defmodule FocalApiWeb.PackageController do
 
     with {:ok, %Package{}} <- Clients.delete_package(package) do
       send_resp(conn, :no_content, "")
+    end
+  end
+
+  defp authorize_user_by_package_uuid(conn, _params) do
+    package = conn.params["package_uuid"]
+    |> Clients.get_package_by_uuid!
+    |> Repo.preload(:client)
+
+    packages_user = Accounts.get_user!(package.client.user_id)
+
+    current_user = conn.assigns[:user]
+
+    if current_user != nil && packages_user.uuid == current_user.uuid do
+      conn
+    else
+      conn
+      |> put_status(:forbidden)
+      |> put_view(FocalApiWeb.ErrorView)
+      |> render("403.json")
+      |> halt()
     end
   end
 end

--- a/lib/focal_api_web/controllers/package_controller.ex
+++ b/lib/focal_api_web/controllers/package_controller.ex
@@ -1,0 +1,52 @@
+defmodule FocalApiWeb.PackageController do
+  use FocalApiWeb, :controller
+
+  alias FocalApi.Clients
+  alias FocalApi.Clients.Package
+
+  action_fallback FocalApiWeb.FallbackController
+
+  def index(conn, _params) do
+    packages = Clients.list_packages()
+    render(conn, "index.json", packages: packages)
+  end
+
+  def create(conn, params) do
+    client = Clients.get_client_by_uuid!(params["client_uuid"])
+
+    create_attrs = params
+    |> Map.put("client_id", client.id)
+    |> Map.put_new("uuid", Ecto.UUID.generate)
+
+    with {:ok, %Package{} = package} <- Clients.create_package(create_attrs) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.package_path(conn, :show, params["client_uuid"], package.uuid))
+      |> render("show.json", package: package)
+    end
+  end
+
+  def show(conn, %{"package_uuid" => package_uuid}) do
+    package = Clients.get_package_by_uuid!(package_uuid)
+    render(conn, "show.json", package: package)
+  end
+
+  def update(conn, params) do
+    package = Clients.get_package_by_uuid!(params["package_uuid"])
+
+    update_attrs = params
+    |> Map.put("uuid", package.uuid)
+
+    with {:ok, %Package{} = package} <- Clients.update_package(package, update_attrs) do
+      render(conn, "show.json", package: package)
+    end
+  end
+
+  def delete(conn, %{"package_uuid" => package_uuid}) do
+    package = Clients.get_package_by_uuid!(package_uuid)
+
+    with {:ok, %Package{}} <- Clients.delete_package(package) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/focal_api_web/controllers/package_controller.ex
+++ b/lib/focal_api_web/controllers/package_controller.ex
@@ -6,6 +6,9 @@ defmodule FocalApiWeb.PackageController do
 
   action_fallback FocalApiWeb.FallbackController
 
+  plug FocalApiWeb.Plugs.AuthenticateSession when action in [:create, :update, :delete, :index, :show]
+  plug FocalApiWeb.Plugs.AuthorizeUserByClientUUID when action in [:create, :update, :delete, :show, :index]
+
   def index(conn, _params) do
     packages = Clients.list_packages()
     render(conn, "index.json", packages: packages)

--- a/lib/focal_api_web/controllers/task_controller.ex
+++ b/lib/focal_api_web/controllers/task_controller.ex
@@ -1,0 +1,62 @@
+defmodule FocalApiWeb.TaskController do
+  use FocalApiWeb, :controller
+
+  alias FocalApi.Clients
+  alias FocalApi.Clients.Task
+
+  action_fallback FocalApiWeb.FallbackController
+
+  def index_by_client(conn, _params) do
+    tasks = Clients.list_tasks_by_client(conn.params["client_uuid"])
+    render(conn, "index.json", tasks: tasks)
+  end
+
+  def create(conn, params) do
+    client = params["client_uuid"]
+    |> Clients.get_client_by_uuid!()
+
+    event = params["event_uuid"]
+    |> Clients.get_event_by_uuid()
+
+    event_id = cond do
+      event == nil -> nil
+      true -> event.id
+    end
+
+    create_attrs = params
+    |> Map.put("client_id", client.id)
+    |> Map.put("event_id", event_id)
+    |> Map.put_new("uuid", Ecto.UUID.generate)
+
+    with {:ok, %Task{} = task} <- Clients.create_task(create_attrs) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.task_path(conn, :show, task))
+      |> render("show.json", task: task)
+    end
+  end
+
+  def show(conn, %{"task_uuid" => task_uuid}) do
+    task = Clients.get_task_by_uuid!(task_uuid)
+    render(conn, "show.json", task: task)
+  end
+
+  def update(conn, params) do
+    task = Clients.get_task_by_uuid!(params["task_uuid"])
+
+    update_attrs = params
+    |> Map.put("uuid", task.uuid)
+
+    with {:ok, %Task{} = task} <- Clients.update_task(task, update_attrs) do
+      render(conn, "show.json", task: task)
+    end
+  end
+
+  def delete(conn, %{"task_uuid" => task_uuid}) do
+    task = Clients.get_task_by_uuid!(task_uuid)
+
+    with {:ok, %Task{}} <- Clients.delete_task(task) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/focal_api_web/plugs/authorize_user_by_client_uuid.ex
+++ b/lib/focal_api_web/plugs/authorize_user_by_client_uuid.ex
@@ -1,0 +1,31 @@
+defmodule FocalApiWeb.Plugs.AuthorizeUserByClientUUID do
+  import Plug.Conn
+  use FocalApiWeb, :controller
+
+  alias FocalApi.Clients
+  alias FocalApi.Repo
+  alias FocalApi.Accounts
+
+  def init(_params) do
+  end
+
+  def call(conn, _params) do
+    client = conn.params["client_uuid"]
+    |> Clients.get_client_by_uuid!
+    |> Repo.preload(:user)
+
+    clients_user = Accounts.get_user!(client.user_id)
+
+    current_user = conn.assigns[:user]
+
+    if current_user != nil && clients_user.uuid == current_user.uuid do
+      conn
+    else
+      conn
+      |> put_status(:forbidden)
+      |> put_view(FocalApiWeb.ErrorView)
+      |> render("403.json")
+      |> halt()
+    end
+  end
+end

--- a/lib/focal_api_web/plugs/authorize_user_by_package_uuid.ex
+++ b/lib/focal_api_web/plugs/authorize_user_by_package_uuid.ex
@@ -1,0 +1,31 @@
+defmodule FocalApiWeb.Plugs.AuthorizeUserByPackageUUID do
+  import Plug.Conn
+  use FocalApiWeb, :controller
+
+  alias FocalApi.Clients
+  alias FocalApi.Repo
+  alias FocalApi.Accounts
+
+  def init(_params) do
+  end
+
+  def call(conn, _params) do
+    package = conn.params["package_uuid"]
+    |> Clients.get_package_by_uuid!
+    |> Repo.preload(:client)
+
+    packages_user = Accounts.get_user!(package.client.user_id)
+
+    current_user = conn.assigns[:user]
+
+    if current_user != nil && packages_user.uuid == current_user.uuid do
+      conn
+    else
+      conn
+      |> put_status(:forbidden)
+      |> put_view(FocalApiWeb.ErrorView)
+      |> render("403.json")
+      |> halt()
+    end
+  end
+end

--- a/lib/focal_api_web/router.ex
+++ b/lib/focal_api_web/router.ex
@@ -25,6 +25,12 @@ defmodule FocalApiWeb.Router do
     put "/package/:package_uuid", PackageController, :update
     delete "/package/:package_uuid", PackageController, :delete
 
+    get "/package/:package_uuid/events", EventController, :index_by_package
+    post "/package/:package_uuid/event", EventController, :create
+    get "/event/:event_uuid", EventController, :show
+    put "/event/:event_uuid", EventController, :update
+    delete "/event/:event_uuid", EventController, :delete
+
     get "/user/:user_uuid/clients", ClientController, :index_by_user
     resources "/client", ClientController, only: [:show, :create, :update, :delete], param: "client_uuid"
 

--- a/lib/focal_api_web/router.ex
+++ b/lib/focal_api_web/router.ex
@@ -37,6 +37,7 @@ defmodule FocalApiWeb.Router do
     put "/task/:task_uuid", TaskController, :update
     delete "/task/:task_uuid", TaskController, :delete
 
+    get "/client/:client_uuid/data", ClientController, :show_all_client_data
     get "/user/:user_uuid/clients", ClientController, :index_by_user
     resources "/client", ClientController, only: [:show, :create, :update, :delete], param: "client_uuid"
 

--- a/lib/focal_api_web/router.ex
+++ b/lib/focal_api_web/router.ex
@@ -19,10 +19,17 @@ defmodule FocalApiWeb.Router do
   scope "/api", FocalApiWeb do
     pipe_through :api
 
-    resources "/clients", ClientController, only: [:show, :create, :update, :delete], param: "client_uuid"
-    resources "/clients/:client_uuid/packages", PackageController, except: [:new, :edit], param: "package_uuid"
-    resources "/users", UserController, only: [:show, :index, :create], param: "user_uuid"
-    get "/users/:user_uuid/clients", ClientController, :index_by_user
+    get "/client/:client_uuid/packages", PackageController, :index_by_client
+    post "/client/:client_uuid/package", PackageController, :create
+    get "/package/:package_uuid", PackageController, :show
+    put "/package/:package_uuid", PackageController, :update
+    delete "/package/:package_uuid", PackageController, :delete
+
+    get "/user/:user_uuid/clients", ClientController, :index_by_user
+    resources "/client", ClientController, only: [:show, :create, :update, :delete], param: "client_uuid"
+
+    get "/users", UserController, :index
+    resources "/user", UserController, only: [:show, :create], param: "user_uuid"
   end
 
   scope "/auth", FocalApiWeb do

--- a/lib/focal_api_web/router.ex
+++ b/lib/focal_api_web/router.ex
@@ -20,6 +20,7 @@ defmodule FocalApiWeb.Router do
     pipe_through :api
 
     resources "/clients", ClientController, only: [:show, :create, :update, :delete], param: "client_uuid"
+    resources "/clients/:client_uuid/packages", PackageController, except: [:new, :edit], param: "package_uuid"
     resources "/users", UserController, only: [:show, :index, :create], param: "user_uuid"
     get "/users/:user_uuid/clients", ClientController, :index_by_user
   end

--- a/lib/focal_api_web/router.ex
+++ b/lib/focal_api_web/router.ex
@@ -31,6 +31,12 @@ defmodule FocalApiWeb.Router do
     put "/event/:event_uuid", EventController, :update
     delete "/event/:event_uuid", EventController, :delete
 
+    get "/client/:client_uuid/tasks", TaskController, :index_by_client
+    post "/client/:client_uuid/task", TaskController, :create
+    get "/task/:task_uuid", TaskController, :show
+    put "/task/:task_uuid", TaskController, :update
+    delete "/task/:task_uuid", TaskController, :delete
+
     get "/user/:user_uuid/clients", ClientController, :index_by_user
     resources "/client", ClientController, only: [:show, :create, :update, :delete], param: "client_uuid"
 

--- a/lib/focal_api_web/router.ex
+++ b/lib/focal_api_web/router.ex
@@ -39,6 +39,7 @@ defmodule FocalApiWeb.Router do
 
     get "/client/:client_uuid/data", ClientController, :show_all_client_data
     get "/user/:user_uuid/clients", ClientController, :index_by_user
+    get "/user/:user_uuid/clients/data", ClientController, :index_of_all_client_data_by_user
     resources "/client", ClientController, only: [:show, :create, :update, :delete], param: "client_uuid"
 
     get "/users", UserController, :index

--- a/lib/focal_api_web/views/client_view.ex
+++ b/lib/focal_api_web/views/client_view.ex
@@ -1,7 +1,10 @@
 defmodule FocalApiWeb.ClientView do
   use FocalApiWeb, :view
   alias FocalApiWeb.ClientView
+  alias FocalApiWeb.TaskView
+  alias FocalApiWeb.PackageView
   alias FocalApi.Clients.Client
+  alias FocalApi.Clients
   alias FocalApi.Repo
 
   def render("index.json", %{clients: clients}) do
@@ -12,12 +15,32 @@ defmodule FocalApiWeb.ClientView do
     %{data: render_one(client, ClientView, "client.json")}
   end
 
+  def render("show_all_client_data.json", %{client: client}) do
+    %{data: render_one(client, ClientView, "all_client_data.json")}
+  end
+
   def render("client.json", %{client: client}) do
     user_uuid = user_uuid(client.uuid)
     %{
       client_name: client.client_name,
       uuid: client.uuid,
       user_uuid: user_uuid
+    }
+  end
+
+  def render("all_client_data.json", %{client: client}) do
+    user_uuid = user_uuid(client.uuid)
+    packages = Clients.list_packages_by_client(client.uuid)
+    first_uncompleted_task = Clients.list_first_uncompleted_task_by_client(client.uuid)
+    current_stage = if (length(first_uncompleted_task) == 0), do: %{}, else: render_one(Enum.at(first_uncompleted_task, 0), TaskView, "task.json")
+    package = render_one(Enum.at(packages, 0), PackageView, "package_with_events.json")
+
+    %{
+      client_name: client.client_name,
+      uuid: client.uuid,
+      user_uuid: user_uuid,
+      package: package,
+      current_stage: current_stage
     }
   end
 

--- a/lib/focal_api_web/views/client_view.ex
+++ b/lib/focal_api_web/views/client_view.ex
@@ -11,6 +11,10 @@ defmodule FocalApiWeb.ClientView do
     %{data: render_many(clients, ClientView, "client.json")}
   end
 
+  def render("index_of_all_client_data.json", %{clients: clients}) do
+    %{data: render_many(clients, ClientView, "all_client_data.json")}
+  end
+
   def render("show.json", %{client: client}) do
     %{data: render_one(client, ClientView, "client.json")}
   end

--- a/lib/focal_api_web/views/event_view.ex
+++ b/lib/focal_api_web/views/event_view.ex
@@ -1,7 +1,7 @@
 defmodule FocalApiWeb.EventView do
   use FocalApiWeb, :view
   alias FocalApiWeb.EventView
-  alias FocalApi.TestHelpers
+  alias FocalApi.Clients
 
   def render("index.json", %{events: events}) do
     %{data: render_many(events, EventView, "event.json")}
@@ -12,13 +12,14 @@ defmodule FocalApiWeb.EventView do
   end
 
   def render("event.json", %{event: event}) do
-    event = TestHelpers.preloaded_event(event.uuid)
+    client = Clients.get_client!(event.client_id)
+    package = Clients.get_package!(event.package_id)
     %{
       event_name: event.event_name,
       shoot_date: event.shoot_date,
       uuid: event.uuid,
-      package_uuid: event.package.uuid,
-      client_uuid: event.client.uuid
+      package_uuid: package.uuid,
+      client_uuid: client.uuid
     }
   end
 end

--- a/lib/focal_api_web/views/event_view.ex
+++ b/lib/focal_api_web/views/event_view.ex
@@ -1,0 +1,24 @@
+defmodule FocalApiWeb.EventView do
+  use FocalApiWeb, :view
+  alias FocalApiWeb.EventView
+  alias FocalApi.TestHelpers
+
+  def render("index.json", %{events: events}) do
+    %{data: render_many(events, EventView, "event.json")}
+  end
+
+  def render("show.json", %{event: event}) do
+    %{data: render_one(event, EventView, "event.json")}
+  end
+
+  def render("event.json", %{event: event}) do
+    event = TestHelpers.preloaded_event(event.uuid)
+    %{
+      event_name: event.event_name,
+      shoot_date: event.shoot_date,
+      uuid: event.uuid,
+      package_uuid: event.package.uuid,
+      client_uuid: event.client.uuid
+    }
+  end
+end

--- a/lib/focal_api_web/views/package_view.ex
+++ b/lib/focal_api_web/views/package_view.ex
@@ -1,0 +1,31 @@
+defmodule FocalApiWeb.PackageView do
+  use FocalApiWeb, :view
+  alias FocalApiWeb.PackageView
+  alias FocalApi.Clients
+  alias FocalApi.Repo
+
+  def render("index.json", %{packages: packages}) do
+    %{data: render_many(packages, PackageView, "package.json")}
+  end
+
+  def render("show.json", %{package: package}) do
+    %{data: render_one(package, PackageView, "package.json")}
+  end
+
+  def render("package.json", %{package: package}) do
+    client_uuid = client_uuid(package.uuid)
+    %{
+      package_name: package.package_name,
+      uuid: package.uuid,
+      client_uuid: client_uuid
+    }
+  end
+
+  defp client_uuid(uuid) do
+    package = uuid
+    |> Clients.get_package_by_uuid!
+    |> Repo.preload(:client)
+
+    package.client.uuid
+  end
+end

--- a/lib/focal_api_web/views/package_view.ex
+++ b/lib/focal_api_web/views/package_view.ex
@@ -1,6 +1,7 @@
 defmodule FocalApiWeb.PackageView do
   use FocalApiWeb, :view
   alias FocalApiWeb.PackageView
+  alias FocalApiWeb.EventView
   alias FocalApi.Clients
   alias FocalApi.Repo
 
@@ -18,6 +19,17 @@ defmodule FocalApiWeb.PackageView do
       package_name: package.package_name,
       uuid: package.uuid,
       client_uuid: client_uuid
+    }
+  end
+
+  def render("package_with_events.json", %{package: package}) do
+    client_uuid = client_uuid(package.uuid)
+    package_events = Clients.list_events_by_package(package.uuid)
+    %{
+      package_name: package.package_name,
+      uuid: package.uuid,
+      client_uuid: client_uuid,
+      package_events: render_many(package_events, EventView, "event.json")
     }
   end
 

--- a/lib/focal_api_web/views/task_view.ex
+++ b/lib/focal_api_web/views/task_view.ex
@@ -1,0 +1,26 @@
+defmodule FocalApiWeb.TaskView do
+  use FocalApiWeb, :view
+  alias FocalApiWeb.TaskView
+  alias FocalApi.TestHelpers
+
+  def render("index.json", %{tasks: tasks}) do
+    %{data: render_many(tasks, TaskView, "task.json")}
+  end
+
+  def render("show.json", %{task: task}) do
+    %{data: render_one(task, TaskView, "task.json")}
+  end
+
+  def render("task.json", %{task: task}) do
+    task = TestHelpers.preloaded_task(task.uuid)
+    event_uuid = if (is_nil(task.event)), do: nil, else: task.event.uuid
+    %{
+      uuid: task.uuid,
+      category: task.category,
+      step: task.step,
+      is_completed: task.is_completed,
+      client_uuid: task.client.uuid,
+      event_uuid: event_uuid
+    }
+  end
+end

--- a/lib/focal_api_web/views/task_view.ex
+++ b/lib/focal_api_web/views/task_view.ex
@@ -1,7 +1,8 @@
 defmodule FocalApiWeb.TaskView do
   use FocalApiWeb, :view
+
   alias FocalApiWeb.TaskView
-  alias FocalApi.TestHelpers
+  alias FocalApi.Clients
 
   def render("index.json", %{tasks: tasks}) do
     %{data: render_many(tasks, TaskView, "task.json")}
@@ -12,14 +13,15 @@ defmodule FocalApiWeb.TaskView do
   end
 
   def render("task.json", %{task: task}) do
-    task = TestHelpers.preloaded_task(task.uuid)
-    event_uuid = if (is_nil(task.event)), do: nil, else: task.event.uuid
+    client = Clients.get_client!(task.client_id)
+    event = Clients.get_event(task.event_id)
+    event_uuid = if (is_nil(event)), do: nil, else: event.uuid
     %{
       uuid: task.uuid,
       category: task.category,
       step: task.step,
       is_completed: task.is_completed,
-      client_uuid: task.client.uuid,
+      client_uuid: client.uuid,
       event_uuid: event_uuid
     }
   end

--- a/priv/repo/migrations/20190912221844_create_packages.exs
+++ b/priv/repo/migrations/20190912221844_create_packages.exs
@@ -1,0 +1,18 @@
+defmodule FocalApi.Repo.Migrations.CreatePackages do
+  use Ecto.Migration
+
+  def change do
+    create table(:packages) do
+      add :package_name, :string
+      add :uuid, :uuid
+      add :client_id, references(:clients)
+
+      timestamps()
+    end
+
+  end
+
+  def down do
+    drop_if_exists table("packages")
+  end
+end

--- a/priv/repo/migrations/20190913002847_create_events.exs
+++ b/priv/repo/migrations/20190913002847_create_events.exs
@@ -1,0 +1,20 @@
+defmodule FocalApi.Repo.Migrations.CreateEvents do
+  use Ecto.Migration
+
+  def change do
+    create table(:events) do
+      add :event_name, :string
+      add :shoot_date, :utc_datetime
+      add :uuid, :uuid
+      add :client_id, references(:clients)
+      add :package_id, references(:packages)
+
+      timestamps()
+    end
+
+  end
+
+  def down do
+    drop_if_exists table("events")
+  end
+end

--- a/priv/repo/migrations/20190913151337_create_tasks.exs
+++ b/priv/repo/migrations/20190913151337_create_tasks.exs
@@ -1,0 +1,19 @@
+defmodule FocalApi.Repo.Migrations.CreateTasks do
+  use Ecto.Migration
+
+  def change do
+    create table(:tasks) do
+      add :uuid, :uuid
+      add :category, :text
+      add :step, :text
+      add :is_completed, :boolean, default: false, null: false
+      add :event_id, references(:events, on_delete: :nothing)
+      add :client_id, references(:clients, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:tasks, [:event_id])
+    create index(:tasks, [:client_id])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,34 +10,119 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
+alias FocalApi.Clients
 alias FocalApi.Clients.Client
 alias FocalApi.Clients.Package
+alias FocalApi.Clients.Event
+alias FocalApi.Clients.Task
 alias FocalApi.Accounts.User
+alias FocalApi.Accounts
 alias FocalApi.Repo
 
-user = %User{
-  avatar: "avatar-image",
-  email: "user@gmail.com",
-  first_name: "First User",
-  provider: "google",
-  uuid: Ecto.UUID.generate(),
-}
-Repo.insert!(user)
-user = Repo.get_by(User, uuid: user.uuid)
+# user = %User{
+#   avatar: "avatar-image",
+#   email: "user@gmail.com",
+#   first_name: "First User",
+#   provider: "google",
+#   uuid: Ecto.UUID.generate(),
+# }
+# Repo.insert!(user)
+# user = Repo.get_by(User, uuid: user.uuid)
+
+# client = %Client{
+#   client_name: "Snow White",
+#   uuid: Ecto.UUID.generate(),
+#   user_id: user.id
+# }
+# Repo.insert!(client)
+# client = Repo.get_by(Client, uuid: client.uuid)
+
+# package = %Package{
+#   package_name: "Engagements",
+#   uuid: Ecto.UUID.generate(),
+#   client_id: client.id
+# }
+# Repo.insert!(package)
+# package = Repo.get_by(Package, uuid: package.uuid)
 
 
-client = %Client{
-  client_name: "Snow White",
-  uuid: Ecto.UUID.generate(),
-  user_id: user.id
-}
-Repo.insert!(client)
-client = Repo.get_by(Client, uuid: client.uuid)
+{:ok, date, _} = DateTime.from_iso8601("2020-04-17T14:00:00Z")
+date = date |> DateTime.truncate(:second)
 
-package = %Package{
-  package_name: "Engagements",
+francesca = Accounts.get_user_by_email("littlegangwolf@gmail.com")
+
+# Francesca Client 1
+francesca_client = %Client{
+  client_name: "Natasha & Zihao",
   uuid: Ecto.UUID.generate(),
-  client_id: client.id
+  user_id: francesca.id
 }
-Repo.insert!(package)
-package = Repo.get_by(Package, uuid: package.uuid)
+Repo.insert!(francesca_client)
+francesca_client = Repo.get_by(Client, uuid: francesca_client.uuid)
+
+francesca_client_package = %Package{
+  package_name: "Wedding Premier",
+  uuid: Ecto.UUID.generate(),
+  client_id: francesca_client.id
+}
+Repo.insert!(francesca_client_package)
+francesca_client_package = Repo.get_by(Package, uuid: francesca_client_package.uuid)
+
+francesca_client_event = %Event{
+  event_name: "Engagement",
+  shoot_date: date,
+  uuid: Ecto.UUID.generate(),
+  client_id: francesca_client.id,
+  package_id: francesca_client_package.id
+}
+Repo.insert!(francesca_client_event)
+francesca_client_event = Repo.get_by(Event, uuid: francesca_client_event.uuid)
+
+francesca_client_task = %Task{
+  category: "New Client Inquiry",
+  is_completed: false,
+  step: "Request More Information",
+  uuid: Ecto.UUID.generate(),
+  client_id: francesca_client.id,
+  event_id: francesca_client_event.id
+}
+Repo.insert!(francesca_client_task)
+francesca_client_task = Repo.get_by(Task, uuid: francesca_client_task.uuid)
+
+# Francesca Client 2
+francesca_client2 = %Client{
+  client_name: "Andrew & Diane",
+  uuid: Ecto.UUID.generate(),
+  user_id: francesca.id
+}
+Repo.insert!(francesca_client2)
+francesca_client2 = Repo.get_by(Client, uuid: francesca_client2.uuid)
+
+francesca_client_package2 = %Package{
+  package_name: "Wedding Classic",
+  uuid: Ecto.UUID.generate(),
+  client_id: francesca_client2.id
+}
+Repo.insert!(francesca_client_package2)
+francesca_client_package2 = Repo.get_by(Package, uuid: francesca_client_package2.uuid)
+
+francesca_client_event2 = %Event{
+  event_name: "Engagement",
+  shoot_date: date,
+  uuid: Ecto.UUID.generate(),
+  client_id: francesca_client2.id,
+  package_id: francesca_client_package2.id
+}
+Repo.insert!(francesca_client_event2)
+francesca_client_event2 = Repo.get_by(Event, uuid: francesca_client_event2.uuid)
+
+francesca_client_task2 = %Task{
+  category: "Proposal & Retainer",
+  is_completed: false,
+  step: "Confirm Proposal & Retainer",
+  uuid: Ecto.UUID.generate(),
+  client_id: francesca_client2.id,
+  event_id: francesca_client_event2.id
+}
+Repo.insert!(francesca_client_task2)
+francesca_client_task2 = Repo.get_by(Task, uuid: francesca_client_task2.uuid)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,6 +11,7 @@
 # and so on) as they will fail if something goes wrong.
 
 alias FocalApi.Clients.Client
+alias FocalApi.Clients.Package
 alias FocalApi.Accounts.User
 alias FocalApi.Repo
 
@@ -22,12 +23,21 @@ user = %User{
   uuid: Ecto.UUID.generate(),
 }
 Repo.insert!(user)
-
 user = Repo.get_by(User, uuid: user.uuid)
 
-Repo.insert!(
-  %Client{
-    client_name: "Snow White",
-    uuid: Ecto.UUID.generate(),
-    user_id: user.id
-})
+
+client = %Client{
+  client_name: "Snow White",
+  uuid: Ecto.UUID.generate(),
+  user_id: user.id
+}
+Repo.insert!(client)
+client = Repo.get_by(Client, uuid: client.uuid)
+
+package = %Package{
+  package_name: "Engagements",
+  uuid: Ecto.UUID.generate(),
+  client_id: client.id
+}
+Repo.insert!(package)
+package = Repo.get_by(Package, uuid: package.uuid)

--- a/test/focal_api/clients/package_test.exs
+++ b/test/focal_api/clients/package_test.exs
@@ -1,0 +1,27 @@
+defmodule FocalApi.PackageTest do
+  use FocalApi.DataCase
+
+  alias FocalApi.Clients.Package
+  alias FocalApi.TestHelpers
+
+  setup do
+    client = TestHelpers.client_fixture(%{ client_name: "John" })
+
+    package = Repo.insert!(%Package{
+      package_name: "Engagements",
+      client_id: client.id,
+      uuid: Ecto.UUID.generate()})
+
+    {:ok, package: package}
+  end
+
+  test "package belongs to a client", context do
+    package = Package
+    |> Repo.get(context[:package].id)
+    |> Repo.preload(:client)
+
+    expected_client = package.client
+
+    assert expected_client.client_name == "John"
+  end
+end

--- a/test/focal_api/clients_test.exs
+++ b/test/focal_api/clients_test.exs
@@ -155,4 +155,83 @@ defmodule FocalApi.ClientsTest do
       assert %Ecto.Changeset{} = Clients.change_package(package)
     end
   end
+
+  describe "events" do
+    alias FocalApi.Clients.Event
+
+    @valid_attrs %{event_name: "some event_name", shoot_date: "2010-04-17T14:00:00Z", uuid: "7488a646-e31f-11e4-aace-600308960662"}
+    @update_attrs %{event_name: "some updated event_name", shoot_date: "2011-05-18T15:01:01Z", uuid: "7488a646-e31f-11e4-aace-600308960668"}
+    @invalid_attrs %{event_name: nil, shoot_date: nil, uuid: nil}
+
+    def event_fixture(attrs \\ %{}) do
+      {:ok, event} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Clients.create_event()
+
+      event
+    end
+
+    test "list_events/0 returns all events" do
+      event = event_fixture()
+      assert Clients.list_events() == [event]
+    end
+
+    test "list_events_by_package/1 returns all packages for a event" do
+      package1 = TestHelpers.package_fixture()
+      package2 = TestHelpers.package_fixture()
+
+      event1 = event_fixture(%{ package_id: package1.id })
+      _event2 = event_fixture(%{ package_id: package2.id })
+      event3 = event_fixture(%{ package_id: package1.id })
+
+      assert Clients.list_events_by_package(package1.uuid) == [event1, event3]
+    end
+
+    test "get_event!/1 returns the event with given id" do
+      event = event_fixture()
+      assert Clients.get_event!(event.id) == event
+    end
+
+    test "get_event_by_uuid!/1 returns the event with given uuid" do
+      event = event_fixture()
+      assert Clients.get_event_by_uuid!(event.uuid) == event
+    end
+
+    test "create_event/1 with valid data creates a event" do
+      assert {:ok, %Event{} = event} = Clients.create_event(@valid_attrs)
+      assert event.event_name == "some event_name"
+      assert event.shoot_date == DateTime.from_naive!(~N[2010-04-17T14:00:00Z], "Etc/UTC")
+      assert event.uuid == "7488a646-e31f-11e4-aace-600308960662"
+    end
+
+    test "create_event/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Clients.create_event(@invalid_attrs)
+    end
+
+    test "update_event/2 with valid data updates the event" do
+      event = event_fixture()
+      assert {:ok, %Event{} = event} = Clients.update_event(event, @update_attrs)
+      assert event.event_name == "some updated event_name"
+      assert event.shoot_date == DateTime.from_naive!(~N[2011-05-18T15:01:01Z], "Etc/UTC")
+      assert event.uuid == "7488a646-e31f-11e4-aace-600308960668"
+    end
+
+    test "update_event/2 with invalid data returns error changeset" do
+      event = event_fixture()
+      assert {:error, %Ecto.Changeset{}} = Clients.update_event(event, @invalid_attrs)
+      assert event == Clients.get_event!(event.id)
+    end
+
+    test "delete_event/1 deletes the event" do
+      event = event_fixture()
+      assert {:ok, %Event{}} = Clients.delete_event(event)
+      assert_raise Ecto.NoResultsError, fn -> Clients.get_event!(event.id) end
+    end
+
+    test "change_event/1 returns a event changeset" do
+      event = event_fixture()
+      assert %Ecto.Changeset{} = Clients.change_event(event)
+    end
+  end
 end

--- a/test/focal_api/clients_test.exs
+++ b/test/focal_api/clients_test.exs
@@ -100,6 +100,17 @@ defmodule FocalApi.ClientsTest do
       assert Clients.list_packages() == [package]
     end
 
+    test "list_packages_by_client/1 returns all packages for a client" do
+      client1 = TestHelpers.client_fixture()
+      client2 = TestHelpers.client_fixture()
+
+      package1 = package_fixture(%{ client_id: client1.id })
+      _package2 = package_fixture(%{ client_id: client2.id })
+      package3 = package_fixture(%{ client_id: client1.id })
+
+      assert Clients.list_packages_by_client(client1.uuid) == [package1, package3]
+    end
+
     test "get_package!/1 returns the package with given id" do
       package = package_fixture()
       assert Clients.get_package!(package.id) == package

--- a/test/focal_api/clients_test.exs
+++ b/test/focal_api/clients_test.exs
@@ -234,4 +234,91 @@ defmodule FocalApi.ClientsTest do
       assert %Ecto.Changeset{} = Clients.change_event(event)
     end
   end
+
+  describe "tasks" do
+    alias FocalApi.Clients.Task
+
+    @valid_attrs %{category: "some category", is_completed: true, step: "some step", uuid: "7488a646-e31f-11e4-aace-600308960662"}
+    @update_attrs %{category: "some updated category", is_completed: false, step: "some updated step", uuid: "7488a646-e31f-11e4-aace-600308960668"}
+    @invalid_attrs %{category: nil, is_completed: nil, step: nil, uuid: nil}
+
+    def task_fixture(attrs \\ %{}) do
+      {:ok, task} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Clients.create_task()
+
+      task
+    end
+
+    test "list_tasks/0 returns all tasks" do
+      task = task_fixture()
+      assert Clients.list_tasks() == [task]
+    end
+
+    test "list_tasks_by_event/1 returns all tasks for a event" do
+      event1 = TestHelpers.event_fixture()
+      event2 = TestHelpers.event_fixture()
+
+      task1 = task_fixture(%{ event_id: event1.id })
+      _task2 = task_fixture(%{ event_id: event2.id })
+      task3 = task_fixture(%{ event_id: event1.id })
+
+      assert Clients.list_tasks_by_event(event1.uuid) == [task1, task3]
+    end
+
+    test "list_tasks_by_client/1 returns all tasks for a client" do
+      client1 = TestHelpers.client_fixture()
+      client2 = TestHelpers.client_fixture()
+
+      task1 = task_fixture(%{ client_id: client1.id })
+      _task2 = task_fixture(%{ client_id: client2.id })
+      task3 = task_fixture(%{ client_id: client1.id })
+
+      assert Clients.list_tasks_by_client(client1.uuid) == [task1, task3]
+    end
+
+    test "get_task!/1 returns the task with given id" do
+      task = task_fixture()
+      assert Clients.get_task!(task.id) == task
+    end
+
+    test "create_task/1 with valid data creates a task" do
+      assert {:ok, %Task{} = task} = Clients.create_task(@valid_attrs)
+      assert task.category == "some category"
+      assert task.is_completed == true
+      assert task.step == "some step"
+      assert task.uuid == "7488a646-e31f-11e4-aace-600308960662"
+    end
+
+    test "create_task/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Clients.create_task(@invalid_attrs)
+    end
+
+    test "update_task/2 with valid data updates the task" do
+      task = task_fixture()
+      assert {:ok, %Task{} = task} = Clients.update_task(task, @update_attrs)
+      assert task.category == "some updated category"
+      assert task.is_completed == false
+      assert task.step == "some updated step"
+      assert task.uuid == "7488a646-e31f-11e4-aace-600308960668"
+    end
+
+    test "update_task/2 with invalid data returns error changeset" do
+      task = task_fixture()
+      assert {:error, %Ecto.Changeset{}} = Clients.update_task(task, @invalid_attrs)
+      assert task == Clients.get_task!(task.id)
+    end
+
+    test "delete_task/1 deletes the task" do
+      task = task_fixture()
+      assert {:ok, %Task{}} = Clients.delete_task(task)
+      assert_raise Ecto.NoResultsError, fn -> Clients.get_task!(task.id) end
+    end
+
+    test "change_task/1 returns a task changeset" do
+      task = task_fixture()
+      assert %Ecto.Changeset{} = Clients.change_task(task)
+    end
+  end
 end

--- a/test/focal_api/clients_test.exs
+++ b/test/focal_api/clients_test.exs
@@ -278,6 +278,15 @@ defmodule FocalApi.ClientsTest do
       assert Clients.list_tasks_by_client(client1.uuid) == [task1, task3]
     end
 
+    test "list_first_uncompleted_task_by_client/1 returns first uncomplete task for a client" do
+      client1 = TestHelpers.client_fixture()
+
+      _task1 = task_fixture(%{ client_id: client1.id, is_completed: true })
+      task2 = task_fixture(%{ client_id: client1.id, is_completed: false })
+
+      assert Clients.list_first_uncompleted_task_by_client(client1.uuid) == [task2]
+    end
+
     test "get_task!/1 returns the task with given id" do
       task = task_fixture()
       assert Clients.get_task!(task.id) == task

--- a/test/focal_api/clients_test.exs
+++ b/test/focal_api/clients_test.exs
@@ -78,4 +78,70 @@ defmodule FocalApi.ClientsTest do
       assert %Ecto.Changeset{} = Clients.change_client(client)
     end
   end
+
+  describe "packages" do
+    alias FocalApi.Clients.Package
+
+    @valid_attrs %{package_name: "some package_name", uuid: "7488a646-e31f-11e4-aace-600308960662"}
+    @update_attrs %{package_name: "some updated package_name", uuid: "7488a646-e31f-11e4-aace-600308960668"}
+    @invalid_attrs %{package_name: nil, uuid: nil}
+
+    def package_fixture(attrs \\ %{}) do
+      {:ok, package} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Clients.create_package()
+
+      package
+    end
+
+    test "list_packages/0 returns all packages" do
+      package = package_fixture()
+      assert Clients.list_packages() == [package]
+    end
+
+    test "get_package!/1 returns the package with given id" do
+      package = package_fixture()
+      assert Clients.get_package!(package.id) == package
+    end
+
+    test "get_package_by_uuid!/1 returns the package with given uuid" do
+      package = package_fixture()
+      assert Clients.get_package_by_uuid!(package.uuid) == package
+    end
+
+    test "create_package/1 with valid data creates a package" do
+      assert {:ok, %Package{} = package} = Clients.create_package(@valid_attrs)
+      assert package.package_name == "some package_name"
+      assert package.uuid == "7488a646-e31f-11e4-aace-600308960662"
+    end
+
+    test "create_package/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Clients.create_package(@invalid_attrs)
+    end
+
+    test "update_package/2 with valid data updates the package" do
+      package = package_fixture()
+      assert {:ok, %Package{} = package} = Clients.update_package(package, @update_attrs)
+      assert package.package_name == "some updated package_name"
+      assert package.uuid == "7488a646-e31f-11e4-aace-600308960668"
+    end
+
+    test "update_package/2 with invalid data returns error changeset" do
+      package = package_fixture()
+      assert {:error, %Ecto.Changeset{}} = Clients.update_package(package, @invalid_attrs)
+      assert package == Clients.get_package!(package.id)
+    end
+
+    test "delete_package/1 deletes the package" do
+      package = package_fixture()
+      assert {:ok, %Package{}} = Clients.delete_package(package)
+      assert_raise Ecto.NoResultsError, fn -> Clients.get_package!(package.id) end
+    end
+
+    test "change_package/1 returns a package changeset" do
+      package = package_fixture()
+      assert %Ecto.Changeset{} = Clients.change_package(package)
+    end
+  end
 end

--- a/test/focal_api_web/controllers/client_controller_test.exs
+++ b/test/focal_api_web/controllers/client_controller_test.exs
@@ -89,6 +89,31 @@ defmodule FocalApiWeb.ClientControllerTest do
     end
   end
 
+  describe "index_of_all_client_data_by_user" do
+    setup [:create_user]
+    test "shows all related data for client", %{conn: conn, user: user} do
+      client = TestHelpers.client_fixture(%{ user_id: user.id })
+      client = TestHelpers.preloaded_client(client.uuid)
+      package = TestHelpers.package_fixture(%{ client_id: client.id })
+      _event1 = TestHelpers.event_fixture(%{ package_id: package.id })
+      _event2 = TestHelpers.event_fixture(%{ package_id: package.id })
+      _task1 = TestHelpers.task_fixture(%{ client_id: client.id, is_completed: true })
+      _task2 = TestHelpers.task_fixture(%{ client_id: client.id, is_completed: false, event_id: nil })
+
+      conn = conn
+      |> TestHelpers.valid_session(client.user)
+      |> get(Routes.client_path(conn, :index_of_all_client_data_by_user, user.uuid))
+
+      assert [%{
+        "client_name" => client_name,
+        "uuid" => client_uuid,
+        "user_uuid" => user_uuid,
+        "current_stage" => current_stage,
+        "package" => package
+      }] = json_response(conn, 200)["data"]
+    end
+  end
+
   describe "create client" do
     setup [:create_user]
     test "renders client when data is valid", %{conn: conn, user: user} do

--- a/test/focal_api_web/controllers/client_controller_test.exs
+++ b/test/focal_api_web/controllers/client_controller_test.exs
@@ -1,10 +1,8 @@
 defmodule FocalApiWeb.ClientControllerTest do
   use FocalApiWeb.ConnCase
 
-  alias FocalApi.Clients
   alias FocalApi.Clients.Client
   alias FocalApi.TestHelpers
-  alias FocalApi.Repo
 
   @create_attrs %{
     client_name: "some client_name",
@@ -24,7 +22,7 @@ defmodule FocalApiWeb.ClientControllerTest do
     setup [:create_client, :create_user]
 
     test "shows chosen client", %{conn: conn, client: client} do
-      client = preloaded_client(client.uuid)
+      client = TestHelpers.preloaded_client(client.uuid)
 
       conn = conn
       |> TestHelpers.valid_session(client.user)
@@ -76,7 +74,7 @@ defmodule FocalApiWeb.ClientControllerTest do
 
       assert %{"uuid" => uuid} = json_response(conn, 201)["data"]
 
-      client = preloaded_client(uuid)
+      client = TestHelpers.preloaded_client(uuid)
 
       assert client.user == user
     end
@@ -108,7 +106,7 @@ defmodule FocalApiWeb.ClientControllerTest do
     setup [:create_client, :create_user]
 
     test "renders client when data is valid", %{conn: conn, client: %Client{uuid: uuid} = _client} do
-      client = preloaded_client(uuid)
+      client = TestHelpers.preloaded_client(uuid)
 
       conn = conn
       |> TestHelpers.valid_session(client.user)
@@ -126,7 +124,7 @@ defmodule FocalApiWeb.ClientControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn, client: client} do
-      client = preloaded_client(client.uuid)
+      client = TestHelpers.preloaded_client(client.uuid)
 
       conn = conn
       |> TestHelpers.valid_session(client.user)
@@ -157,7 +155,7 @@ defmodule FocalApiWeb.ClientControllerTest do
     setup [:create_client, :create_user]
 
     test "deletes chosen client", %{conn: conn, client: client} do
-      client = preloaded_client(client.uuid)
+      client = TestHelpers.preloaded_client(client.uuid)
 
       conn = conn
       |> TestHelpers.valid_session(client.user)
@@ -190,7 +188,7 @@ defmodule FocalApiWeb.ClientControllerTest do
   describe "index_by_user" do
     setup [:create_client, :create_user]
     test "lists all clients for a user", %{conn: conn, client: client} do
-      client = preloaded_client(client.uuid)
+      client = TestHelpers.preloaded_client(client.uuid)
       user_uuid = client.user.uuid
 
       conn = conn
@@ -213,7 +211,7 @@ defmodule FocalApiWeb.ClientControllerTest do
     end
 
     test "renders error when user is logged in but not authorized to make the change", %{conn: conn, client: client, user: user} do
-      client = preloaded_client(client.uuid)
+      client = TestHelpers.preloaded_client(client.uuid)
       user_uuid = client.user.uuid
 
       conn = conn
@@ -226,20 +224,12 @@ defmodule FocalApiWeb.ClientControllerTest do
 
 
   defp create_client(_) do
-    user = TestHelpers.user_fixture()
-    client = TestHelpers.client_fixture(%{ user_id: user.id })
-
+    client = TestHelpers.client_fixture()
     {:ok, client: client}
   end
 
   defp create_user(_) do
     user = TestHelpers.user_fixture()
     {:ok, user: user}
-  end
-
-  defp preloaded_client(uuid) do
-    uuid
-    |> Clients.get_client_by_uuid!
-    |> Repo.preload(:user)
   end
 end

--- a/test/focal_api_web/controllers/event_controller_test.exs
+++ b/test/focal_api_web/controllers/event_controller_test.exs
@@ -1,0 +1,116 @@
+defmodule FocalApiWeb.EventControllerTest do
+  use FocalApiWeb.ConnCase
+
+  alias FocalApi.Clients
+  alias FocalApi.Clients.Event
+  alias FocalApi.TestHelpers
+
+  @create_attrs %{
+    event_name: "some event_name",
+    shoot_date: "2010-04-17T14:00:00Z",
+    uuid: "7488a646-e31f-11e4-aace-600308960662"
+  }
+  @update_attrs %{
+    event_name: "some updated event_name",
+    shoot_date: "2011-05-18T15:01:01Z",
+    uuid: "7488a646-e31f-11e4-aace-600308960668"
+  }
+  @invalid_attrs %{event_name: nil, shoot_date: nil, uuid: nil}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index_by_package" do
+    setup [:create_event]
+    test "lists all events", %{conn: conn, event: event} do
+      event = TestHelpers.preloaded_event(event.uuid)
+
+      conn = get(conn, Routes.event_path(conn, :index_by_package, event.package.uuid))
+      assert length(json_response(conn, 200)["data"]) == 1
+    end
+  end
+
+  describe "create event" do
+    setup [:create_package]
+    test "renders event when data is valid", %{conn: conn, package: package} do
+      package = TestHelpers.preloaded_package(package.uuid)
+      package_client_uuid = package.client.uuid
+      package_uuid = package.uuid
+
+      conn = post(conn, Routes.event_path(conn, :create, package.uuid), @create_attrs)
+      assert %{"uuid" => uuid} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.event_path(conn, :show, uuid))
+
+      assert %{
+               "event_name" => "some event_name",
+               "shoot_date" => "2010-04-17T14:00:00Z",
+               "uuid" => uuid,
+               "client_uuid" => package_client_uuid,
+               "package_uuid" => package_uuid,
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, package: package} do
+      conn = post(conn, Routes.event_path(conn, :create, package.uuid), @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update event" do
+    setup [:create_event]
+
+    test "renders event when data is valid", %{conn: conn, event: %Event{uuid: uuid} = event} do
+      event = TestHelpers.preloaded_event(uuid)
+      client_uuid = event.client.uuid
+      package_uuid = event.package.uuid
+
+      conn = put(conn, Routes.event_path(conn, :update, uuid), @update_attrs)
+      assert %{"uuid" => ^uuid} = json_response(conn, 200)["data"]
+
+      conn = get(conn, Routes.event_path(conn, :show, uuid))
+
+      assert %{
+               "event_name" => "some updated event_name",
+               "shoot_date" => "2011-05-18T15:01:01Z",
+               "uuid" => uuid,
+               "client_uuid" => package_client_uuid,
+               "package_uuid" => package_uuid,
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, event: event} do
+      conn = put(conn, Routes.event_path(conn, :update, event.uuid), @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete event" do
+    setup [:create_event]
+
+    test "deletes chosen event", %{conn: conn, event: event} do
+      conn = delete(conn, Routes.event_path(conn, :delete, event.uuid))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.event_path(conn, :show, event.uuid))
+      end
+    end
+  end
+
+  defp create_package(_) do
+    package = TestHelpers.package_fixture()
+    {:ok, package: package}
+  end
+
+  defp create_event(_) do
+    event = TestHelpers.event_fixture()
+    {:ok, event: event}
+  end
+
+  defp create_client(_) do
+    client = TestHelpers.client_fixture()
+    {:ok, client: client}
+  end
+end

--- a/test/focal_api_web/controllers/package_controller_test.exs
+++ b/test/focal_api_web/controllers/package_controller_test.exs
@@ -1,0 +1,114 @@
+defmodule FocalApiWeb.PackageControllerTest do
+  use FocalApiWeb.ConnCase
+
+  alias FocalApi.Clients
+  alias FocalApi.Clients.Package
+  alias FocalApi.TestHelpers
+  alias FocalApi.Repo
+
+  @create_attrs %{
+    package_name: "some package_name",
+    uuid: "7488a646-e31f-11e4-aace-600308960662"
+  }
+  @update_attrs %{
+    package_name: "some updated package_name",
+    uuid: "7488a646-e31f-11e4-aace-600308960668"
+  }
+  @invalid_attrs %{package_name: nil, uuid: nil}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    setup [:create_client]
+    test "lists all packages", %{conn: conn, client: client} do
+      conn = get(conn, Routes.package_path(conn, :index, client.uuid))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create package" do
+    setup [:create_client]
+    test "renders package when data is valid", %{conn: conn, client: client} do
+      client_uuid = client.uuid
+      conn = post(conn, Routes.package_path(conn, :create, client_uuid), @create_attrs)
+      assert %{"uuid" => uuid} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.package_path(conn, :show, client.uuid, uuid))
+
+      assert %{
+               "package_name" => "some package_name",
+               "uuid" => uuid,
+               "client_uuid" => client_uuid
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, client: client} do
+      conn = post(conn, Routes.package_path(conn, :create, client.uuid), @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update package" do
+    setup [:create_package]
+
+    test "renders package when data is valid", %{conn: conn, package: %Package{uuid: uuid} = _package} do
+      package = preloaded_package(uuid)
+      package_client_uuid = package.client.uuid
+
+      conn = put(conn, Routes.package_path(conn, :update, package_client_uuid, package.uuid), @update_attrs)
+      assert %{"uuid" => ^uuid} = json_response(conn, 200)["data"]
+
+      conn = get(conn, Routes.package_path(conn, :show, package_client_uuid, uuid))
+
+      assert %{
+               "package_name" => "some updated package_name",
+               "uuid" => uuid,
+               "client_uuid" => package_client_uuid
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, package: package} do
+      package = preloaded_package(package.uuid)
+      package_client_uuid = package.client.uuid
+
+      conn = put(conn, Routes.package_path(conn, :update, package_client_uuid, package.uuid), @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete package" do
+    setup [:create_package]
+
+    test "deletes chosen package", %{conn: conn, package: package} do
+      package = preloaded_package(package.uuid)
+      package_client_uuid = package.client.uuid
+
+      conn = delete(conn, Routes.package_path(conn, :delete, package_client_uuid, package.uuid))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.package_path(conn, :show, package_client_uuid, package.uuid))
+      end
+    end
+  end
+
+  defp create_package(_) do
+    package = TestHelpers.package_fixture()
+    {:ok, package: package}
+  end
+
+  defp create_client(_) do
+    user = TestHelpers.user_fixture()
+    client = TestHelpers.client_fixture(%{ user_id: user.id })
+
+    {:ok, client: client}
+  end
+
+  defp preloaded_package(uuid) do
+    uuid
+    |> Clients.get_package_by_uuid!
+    |> Repo.preload(:client)
+  end
+end

--- a/test/focal_api_web/controllers/task_controller_test.exs
+++ b/test/focal_api_web/controllers/task_controller_test.exs
@@ -1,7 +1,6 @@
 defmodule FocalApiWeb.TaskControllerTest do
   use FocalApiWeb.ConnCase
 
-  alias FocalApi.Clients
   alias FocalApi.Clients.Task
   alias FocalApi.TestHelpers
 
@@ -27,16 +26,45 @@ defmodule FocalApiWeb.TaskControllerTest do
     setup [:create_task]
     test "lists all tasks by client", %{conn: conn, task: task} do
       task = TestHelpers.preloaded_task(task.uuid)
+      client = TestHelpers.preloaded_client(task.client.uuid)
 
-      conn = get(conn, Routes.task_path(conn, :index_by_client, task.client.uuid))
+      conn = conn
+      |> TestHelpers.valid_session(client.user)
+      |> get(Routes.task_path(conn, :index_by_client, task.client.uuid))
+
       assert length(json_response(conn, 200)["data"]) == 1
+    end
+
+    test "renders error when user is logged in but request is not authenticated", %{conn: conn, task: task} do
+      task = TestHelpers.preloaded_task(task.uuid)
+
+      conn = conn
+      |> TestHelpers.invalid_session("test_id_token")
+      |> get(Routes.task_path(conn, :index_by_client, task.client.uuid))
+
+      assert json_response(conn, 401)["errors"] != %{}
+    end
+
+    test "renders error when user is logged in but not authorized to view", %{conn: conn, task: task} do
+      task = TestHelpers.preloaded_task(task.uuid)
+
+      conn = conn
+      |> TestHelpers.valid_session(TestHelpers.user_fixture())
+      |> get(Routes.task_path(conn, :index_by_client, task.client.uuid))
+
+      assert json_response(conn, 403)["errors"] != %{}
     end
   end
 
   describe "create task" do
     setup [:create_client]
     test "renders task when data is valid", %{conn: conn, client: client} do
-      conn = post(conn, Routes.task_path(conn, :create, client.uuid), @create_attrs)
+      client = TestHelpers.preloaded_client(client.uuid)
+
+      conn = conn
+      |> TestHelpers.valid_session(client.user)
+      |> post(Routes.task_path(conn, :create, client.uuid), @create_attrs)
+
       assert %{"uuid" => uuid} = json_response(conn, 201)["data"]
 
       conn = get(conn, Routes.task_path(conn, :show, uuid))
@@ -50,18 +78,46 @@ defmodule FocalApiWeb.TaskControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn, client: client} do
-      conn = post(conn, Routes.task_path(conn, :create, client.uuid),  @invalid_attrs)
+      client = TestHelpers.preloaded_client(client.uuid)
+
+      conn = conn
+      |> TestHelpers.valid_session(client.user)
+      |> post(Routes.task_path(conn, :create, client.uuid), @invalid_attrs)
+
       assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "renders error when user is logged in but request is not authenticated", %{conn: conn, client: client} do
+      client = TestHelpers.preloaded_client(client.uuid)
+
+      conn = conn
+      |> TestHelpers.invalid_session("test_id_token")
+      |> post(Routes.task_path(conn, :create, client.uuid), @invalid_attrs)
+
+      assert json_response(conn, 401)["errors"] != %{}
+    end
+
+    test "renders error when user is logged in but not authorized to create", %{conn: conn, client: client} do
+      client = TestHelpers.preloaded_client(client.uuid)
+
+      conn = conn
+      |> TestHelpers.valid_session(TestHelpers.user_fixture())
+      |> post(Routes.task_path(conn, :create, client.uuid), @invalid_attrs)
+
+      assert json_response(conn, 403)["errors"] != %{}
     end
   end
 
   describe "update task" do
     setup [:create_task]
 
-    test "renders task when data is valid", %{conn: conn, task: %Task{uuid: uuid} = task} do
+    test "renders task when data is valid", %{conn: conn, task: %Task{uuid: uuid} = _task} do
       task = TestHelpers.preloaded_task(uuid)
+      client = TestHelpers.preloaded_client(task.client.uuid)
 
-      conn = put(conn, Routes.task_path(conn, :update, uuid), @update_attrs)
+      conn = conn
+      |> TestHelpers.valid_session(client.user)
+      |> put(Routes.task_path(conn, :update, uuid), @update_attrs)
 
       assert %{"uuid" => ^uuid} = json_response(conn, 200)["data"]
 
@@ -78,8 +134,34 @@ defmodule FocalApiWeb.TaskControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn, task: task} do
-      conn = put(conn, Routes.task_path(conn, :update, task.uuid), @invalid_attrs)
+      task = TestHelpers.preloaded_task(task.uuid)
+      client = TestHelpers.preloaded_client(task.client.uuid)
+
+      conn = conn
+      |> TestHelpers.valid_session(client.user)
+      |> put(Routes.task_path(conn, :update, task.uuid), @invalid_attrs)
+
       assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "renders error when user is logged in but request is not authenticated", %{conn: conn, task: task} do
+      task = TestHelpers.preloaded_task(task.uuid)
+
+      conn = conn
+      |> TestHelpers.invalid_session("test_id_token")
+      |> put(Routes.task_path(conn, :update, task.uuid), @invalid_attrs)
+
+      assert json_response(conn, 401)["errors"] != %{}
+    end
+
+    test "renders error when user is logged in but not authorized to update", %{conn: conn, task: task} do
+      task = TestHelpers.preloaded_task(task.uuid)
+
+      conn = conn
+      |> TestHelpers.valid_session(TestHelpers.user_fixture())
+      |> put(Routes.task_path(conn, :update, task.uuid), @invalid_attrs)
+
+      assert json_response(conn, 403)["errors"] != %{}
     end
   end
 
@@ -88,24 +170,42 @@ defmodule FocalApiWeb.TaskControllerTest do
 
     test "deletes chosen task", %{conn: conn, task: task} do
       task = TestHelpers.preloaded_task(task.uuid)
+      client = TestHelpers.preloaded_client(task.client.uuid)
 
-      conn = delete(conn, Routes.task_path(conn, :delete, task.uuid))
+      conn = conn
+      |> TestHelpers.valid_session(client.user)
+      |> delete(Routes.task_path(conn, :delete, task.uuid))
       assert response(conn, 204)
 
       assert_error_sent 404, fn ->
         get(conn, Routes.task_path(conn, :show, task.uuid))
       end
     end
+
+    test "renders error when user is logged in but request is not authenticated", %{conn: conn, task: task} do
+      task = TestHelpers.preloaded_task(task.uuid)
+
+      conn = conn
+      |> TestHelpers.invalid_session("test_id_token")
+      |> delete(Routes.task_path(conn, :delete, task.uuid))
+
+      assert json_response(conn, 401)["errors"] != %{}
+    end
+
+    test "renders error when user is logged in but not authorized to delete", %{conn: conn, task: task} do
+      task = TestHelpers.preloaded_task(task.uuid)
+
+      conn = conn
+      |> TestHelpers.valid_session(TestHelpers.user_fixture())
+      |> delete(Routes.task_path(conn, :delete, task.uuid))
+
+      assert json_response(conn, 403)["errors"] != %{}
+    end
   end
 
   defp create_task(_) do
     task = TestHelpers.task_fixture()
     {:ok, task: task}
-  end
-
-  defp create_event(_) do
-    event = TestHelpers.event_fixture()
-    {:ok, event: event}
   end
 
   defp create_client(_) do

--- a/test/focal_api_web/controllers/task_controller_test.exs
+++ b/test/focal_api_web/controllers/task_controller_test.exs
@@ -1,0 +1,115 @@
+defmodule FocalApiWeb.TaskControllerTest do
+  use FocalApiWeb.ConnCase
+
+  alias FocalApi.Clients
+  alias FocalApi.Clients.Task
+  alias FocalApi.TestHelpers
+
+  @create_attrs %{
+    category: "some category",
+    is_completed: true,
+    step: "some step",
+    uuid: "7488a646-e31f-11e4-aace-600308960662"
+  }
+  @update_attrs %{
+    category: "some updated category",
+    is_completed: false,
+    step: "some updated step",
+    uuid: "7488a646-e31f-11e4-aace-600308960668"
+  }
+  @invalid_attrs %{category: nil, is_completed: nil, step: nil, uuid: nil}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index_by_client" do
+    setup [:create_task]
+    test "lists all tasks by client", %{conn: conn, task: task} do
+      task = TestHelpers.preloaded_task(task.uuid)
+
+      conn = get(conn, Routes.task_path(conn, :index_by_client, task.client.uuid))
+      assert length(json_response(conn, 200)["data"]) == 1
+    end
+  end
+
+  describe "create task" do
+    setup [:create_client]
+    test "renders task when data is valid", %{conn: conn, client: client} do
+      conn = post(conn, Routes.task_path(conn, :create, client.uuid), @create_attrs)
+      assert %{"uuid" => uuid} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.task_path(conn, :show, uuid))
+
+      assert %{
+               "category" => "some category",
+               "is_completed" => true,
+               "step" => "some step",
+               "uuid" => "7488a646-e31f-11e4-aace-600308960662"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, client: client} do
+      conn = post(conn, Routes.task_path(conn, :create, client.uuid),  @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update task" do
+    setup [:create_task]
+
+    test "renders task when data is valid", %{conn: conn, task: %Task{uuid: uuid} = task} do
+      task = TestHelpers.preloaded_task(uuid)
+
+      conn = put(conn, Routes.task_path(conn, :update, uuid), @update_attrs)
+
+      assert %{"uuid" => ^uuid} = json_response(conn, 200)["data"]
+
+      conn = get(conn, Routes.task_path(conn, :show, uuid))
+
+      assert %{
+               "category" => "some updated category",
+               "is_completed" => false,
+               "step" => "some updated step",
+               "uuid" => uuid,
+               "client_uuid" => task_client_uuid,
+                "event_uuid" => task_event_uuid,
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, task: task} do
+      conn = put(conn, Routes.task_path(conn, :update, task.uuid), @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete task" do
+    setup [:create_task]
+
+    test "deletes chosen task", %{conn: conn, task: task} do
+      task = TestHelpers.preloaded_task(task.uuid)
+
+      conn = delete(conn, Routes.task_path(conn, :delete, task.uuid))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.task_path(conn, :show, task.uuid))
+      end
+    end
+  end
+
+  defp create_task(_) do
+    task = TestHelpers.task_fixture()
+    {:ok, task: task}
+  end
+
+  defp create_event(_) do
+    event = TestHelpers.event_fixture()
+    {:ok, event: event}
+  end
+
+  defp create_client(_) do
+    client = TestHelpers.client_fixture()
+    {:ok, client: client}
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -7,6 +7,7 @@ defmodule FocalApi.TestHelpers do
   alias FocalApi.Clients
   alias FocalApi.Clients.Package
   alias FocalApi.Clients.Event
+  alias FocalApi.Clients.Task
 
   def user_fixture(attrs \\ %{}) do
     params =
@@ -83,6 +84,28 @@ defmodule FocalApi.TestHelpers do
       event
   end
 
+  def task_fixture(attrs \\ %{}) do
+    client = client_fixture()
+    event = event_fixture(%{ client_id: client.id })
+
+    params =
+      attrs
+      |> Enum.into(%{
+        category: "some category",
+        is_completed: true,
+        step: "some step",
+        uuid: Ecto.UUID.generate(),
+        client_id: client.id,
+        event_id: event.id
+      })
+
+    {:ok, task} =
+      Task.changeset(%Task{}, params)
+      |> Repo.insert()
+
+      task
+  end
+
   def valid_session(conn, user) do
     conn
     |> assign(:user, user)
@@ -112,5 +135,12 @@ defmodule FocalApi.TestHelpers do
     |> Clients.get_event_by_uuid!
     |> Repo.preload(:client)
     |> Repo.preload(:package)
+  end
+
+  def preloaded_task(uuid) do
+    uuid
+    |> Clients.get_task_by_uuid!
+    |> Repo.preload(:client)
+    |> Repo.preload(:event)
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -6,6 +6,7 @@ defmodule FocalApi.TestHelpers do
   alias FocalApi.Clients.Client
   alias FocalApi.Clients
   alias FocalApi.Clients.Package
+  alias FocalApi.Clients.Event
 
   def user_fixture(attrs \\ %{}) do
     params =
@@ -50,7 +51,7 @@ defmodule FocalApi.TestHelpers do
       attrs
       |> Enum.into(%{
         package_name: "some package_name",
-        uuid: "7488a646-e31f-11e4-aace-600308960662",
+        uuid: Ecto.UUID.generate(),
         client_id: client.id,
       })
 
@@ -59,6 +60,27 @@ defmodule FocalApi.TestHelpers do
       |> Repo.insert()
 
       package
+  end
+
+  def event_fixture(attrs \\ %{}) do
+    client = client_fixture()
+    package = package_fixture(%{ client_id: client.id })
+
+    params =
+      attrs
+      |> Enum.into(%{
+        event_name: "some event_name",
+        shoot_date: "2010-04-17T14:00:00Z",
+        uuid: Ecto.UUID.generate(),
+        client_id: client.id,
+        package_id: package.id
+      })
+
+    {:ok, event} =
+      Event.changeset(%Event{}, params)
+      |> Repo.insert()
+
+      event
   end
 
   def valid_session(conn, user) do
@@ -83,5 +105,12 @@ defmodule FocalApi.TestHelpers do
     uuid
     |> Clients.get_client_by_uuid!
     |> Repo.preload(:user)
+  end
+
+  def preloaded_event(uuid) do
+    uuid
+    |> Clients.get_event_by_uuid!
+    |> Repo.preload(:client)
+    |> Repo.preload(:package)
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -4,6 +4,7 @@ defmodule FocalApi.TestHelpers do
   alias FocalApi.Repo
   alias FocalApi.Accounts.User
   alias FocalApi.Clients.Client
+  alias FocalApi.Clients
   alias FocalApi.Clients.Package
 
   def user_fixture(attrs \\ %{}) do
@@ -70,5 +71,17 @@ defmodule FocalApi.TestHelpers do
 
   def invalid_session(conn, id_token) do
     init_test_session(conn, id: id_token)
+  end
+
+  def preloaded_package(uuid) do
+    uuid
+    |> Clients.get_package_by_uuid!
+    |> Repo.preload(:client)
+  end
+
+  def preloaded_client(uuid) do
+    uuid
+    |> Clients.get_client_by_uuid!
+    |> Repo.preload(:user)
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -92,7 +92,7 @@ defmodule FocalApi.TestHelpers do
       attrs
       |> Enum.into(%{
         category: "some category",
-        is_completed: true,
+        is_completed: false,
         step: "some step",
         uuid: Ecto.UUID.generate(),
         client_id: client.id,

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -4,6 +4,7 @@ defmodule FocalApi.TestHelpers do
   alias FocalApi.Repo
   alias FocalApi.Accounts.User
   alias FocalApi.Clients.Client
+  alias FocalApi.Clients.Package
 
   def user_fixture(attrs \\ %{}) do
     params =
@@ -39,6 +40,24 @@ defmodule FocalApi.TestHelpers do
       |> Repo.insert()
 
     client
+  end
+
+  def package_fixture(attrs \\ %{}) do
+    client = client_fixture()
+
+    params =
+      attrs
+      |> Enum.into(%{
+        package_name: "some package_name",
+        uuid: "7488a646-e31f-11e4-aace-600308960662",
+        client_id: client.id,
+      })
+
+    {:ok, package} =
+      Package.changeset(%Package{}, params)
+      |> Repo.insert()
+
+      package
   end
 
   def valid_session(conn, user) do


### PR DESCRIPTION
# Things Done
### Create routes & authorizations for Packages, Events and Tasks
### Update API Route design
Previously, the routes showed the data hierarchy and relationships of the data model. For example, a package belongs to a client, thus the routes for CRUD package actions were formulated like "/clients/:client_uuid/packages/:package_uuid".  This is unnecessary and following this pattern will be unwieldy if we bring in another concept like Events, which belongs to both Package and Client.

The new route design will only require dependent UUIDs when it makes sense. For example, retrieving a list of packages for a clients will require a client_uuid. Creating a clients package will also require a client_uuid to make it clear that the package will belong to the specified client.

For simple retrieving, updating or deleting of a data model, we can simplify the route to just the one uuid it requires. For example, PUT "/packages/:package_uuid" as opposed to PUT "/clients/:client_uuid/packages/:package_uuid".

Route names should also be singular or plural depending on the action. For example, retrieving/updating/deleting a data should be singular ("client") and retrieving a list of data should be plural ("clients").

##### Intended Route Design
```
GET /api/user/user_uuid/clients // get a index of a users clients
GET /api/client/client_uuid/packages // get a index of clients packages
GET /api/package/package_uuid/events // get a index of packages events
GET /api/client/client_uuid/tasks // get a index of client tasks

GET /api/client/client_uuid  // get a single client
GET /api/package/package_uuid // get a single package
GET /api/event/event_uuid // get a single event
GET /api/task/task_uuid // get a single event

POST /api/client // post a new client for a user (user is grabbed from session)
POST /api/client/client_uuid/package // post a package for a client
POST /api/package/package_uuid/event // post a event for a package
POST /api/client/client_uuid/task // post a task for a client

PUT /api/client/client_uuid
PUT /api/package/package_uuid
PUT /api/event/event_uuid
PUT /api/task/task_uuid

DELETE /api/client/client_uuid
DELETE /api/package/package_uuid
DELETE /api/event/event_uuid
DELETE /api/task/task_uuid
```


### New Route to see all clients related data: `"/client/:client_uuid/data"` 
### New Route to get all clients for a user, with related client data: `"/user/:user_uuid/clients/data"`

##### Current View for clients related data:
```
%{
              "client_name" => "Snow",
              "current_stage" => %{
                "category" => "some category",
                "client_uuid" => "abb9611b-d02c-4dcb-95c9-c870107c7868",
                "event_uuid" => nil,
                "is_completed" => false,
                "step" => "some step",
                "uuid" => "892b73da-87db-4f2b-88b9-6f35f057964b"
              },
              "package" => %{
                "client_uuid" => "abb9611b-d02c-4dcb-95c9-c870107c7868",
                "package_events" => [
                  %{
                    "client_uuid" => "57ea128a-a7ed-4a8d-aabc-d065eb31a003",
                    "event_name" => "some event_name",
                    "package_uuid" => "1162b06c-2f98-4fdb-9d16-600fee9feed6",
                    "shoot_date" => "2010-04-17T14:00:00Z",
                    "uuid" => "82bfa88b-7fb4-44e1-9274-5c5a20db8046"
                  },
                  %{
                    "client_uuid" => "707e9868-7d30-496b-99d3-8c42957b9163",
                    "event_name" => "some event_name",
                    "package_uuid" => "1162b06c-2f98-4fdb-9d16-600fee9feed6",
                    "shoot_date" => "2010-04-17T14:00:00Z",
                    "uuid" => "ab50c0dc-db38-4f7b-8544-aeddc8c4da56"
                  }
                ],
                "package_name" => "some package_name",
                "uuid" => "1162b06c-2f98-4fdb-9d16-600fee9feed6"
              },
              "user_uuid" => "7419d034-a44c-4a72-9edd-a2bd269fab6d",
              "uuid" => "abb9611b-d02c-4dcb-95c9-c870107c7868"
            }
```