### PR TITLE
Update Event schema

### DIFF
--- a/lib/focal_api/clients.ex
+++ b/lib/focal_api/clients.ex
@@ -3,6 +3,7 @@ defmodule FocalApi.Clients do
   alias FocalApi.Repo
   alias FocalApi.Clients.Client
   alias FocalApi.Accounts
+  alias FocalApi.Clients.Event
 
   def list_clients do
     Repo.all(Client)
@@ -54,6 +55,15 @@ defmodule FocalApi.Clients do
 
   def get_package_by_uuid!(uuid), do: Repo.get_by!(Package, uuid: uuid)
 
+  def get_earliest_shoot_date_by_package(package_uuid) do
+    package = get_package_by_uuid!(package_uuid)
+    query = from event in Event,
+              where: ^package.id == event.package_id,
+              order_by: event.shoot_date,
+              limit: 1
+    Repo.one(query, preload: [:event]).shoot_date
+  end
+
   def create_package(attrs \\ %{}) do
     %Package{}
     |> Package.changeset(attrs)
@@ -74,7 +84,6 @@ defmodule FocalApi.Clients do
     Package.changeset(package, %{})
   end
 
-  alias FocalApi.Clients.Event
 
   def list_events do
     Repo.all(Event)

--- a/lib/focal_api/clients/event.ex
+++ b/lib/focal_api/clients/event.ex
@@ -8,7 +8,17 @@ defmodule FocalApi.Clients.Event do
   schema "events" do
     field :event_name, :string
     field :shoot_date, :utc_datetime
+    field :shoot_time, :string
+    field :shoot_location, :string
+    field :edit_image_deadline, :utc_datetime
+    field :gallery_link, :string
+    field :blog_link, :string
+    field :wedding_location, :string
+    field :reception_location, :string
+    field :coordinator_name, :string
+    field :notes, :string
     field :uuid, Ecto.UUID
+
     belongs_to :client, Client
     belongs_to :package, Package
 
@@ -18,7 +28,22 @@ defmodule FocalApi.Clients.Event do
   @doc false
   def changeset(event, attrs) do
     event
-    |> cast(attrs, [:event_name, :shoot_date, :uuid, :client_id, :package_id])
-    |> validate_required([:event_name, :shoot_date, :uuid])
+    |> cast(attrs, [
+      :event_name,
+      :shoot_date,
+      :uuid,
+      :client_id,
+      :package_id,
+      :shoot_time,
+      :shoot_location,
+      :edit_image_deadline,
+      :gallery_link,
+      :blog_link,
+      :notes,
+      :wedding_location,
+      :reception_location,
+      :coordinator_name
+    ])
+    |> validate_required([:event_name, :uuid])
   end
 end

--- a/lib/focal_api_web/views/client_view.ex
+++ b/lib/focal_api_web/views/client_view.ex
@@ -85,7 +85,8 @@ defmodule FocalApiWeb.ClientView do
   end
 
   defp upcoming_shoot_date(package) do
-    if (package != nil && length(package.package_events) > 0), do: Enum.at(package.package_events, 0).shoot_date, else: nil
+    package_exists = package != nil && length(package.package_events) > 0
+    if package_exists, do: Clients.get_earliest_shoot_date_by_package(package.uuid), else: nil
   end
 
   defp current_stage(client_uuid) do

--- a/lib/focal_api_web/views/event_view.ex
+++ b/lib/focal_api_web/views/event_view.ex
@@ -17,6 +17,15 @@ defmodule FocalApiWeb.EventView do
     %{
       event_name: event.event_name,
       shoot_date: event.shoot_date,
+      shoot_time: event.shoot_time,
+      shoot_location: event.shoot_location,
+      edit_image_deadline: event.edit_image_deadline,
+      gallery_link: event.gallery_link,
+      blog_link: event.blog_link,
+      wedding_location: event.wedding_location,
+      reception_location: event.reception_location,
+      coordinator_name: event.coordinator_name,
+      notes: event.notes,
       uuid: event.uuid,
       package_uuid: package.uuid,
       client_uuid: client.uuid

--- a/lib/focal_api_web/views/package_view.ex
+++ b/lib/focal_api_web/views/package_view.ex
@@ -50,14 +50,23 @@ defmodule FocalApiWeb.PackageView do
       balance_received: package.balance_received,
       wedding_included: package.wedding_included,
       engagement_included: package.engagement_included,
+      upcoming_shoot_date: upcoming_shoot_date(package, package_events),
     }
   end
 
   defp client_uuid(uuid) do
-    package = uuid
+    package = preloaded_package(uuid)
+    package.client.uuid
+  end
+
+  defp preloaded_package(uuid) do
+    uuid
     |> Clients.get_package_by_uuid!
     |> Repo.preload(:client)
+  end
 
-    package.client.uuid
+  defp upcoming_shoot_date(package, package_events) do
+    package_exists = package != nil && length(package_events) > 0
+    if package_exists, do: Clients.get_earliest_shoot_date_by_package(package.uuid), else: nil
   end
 end

--- a/priv/repo/migrations/20190919175407_update_event.exs
+++ b/priv/repo/migrations/20190919175407_update_event.exs
@@ -1,0 +1,17 @@
+defmodule FocalApi.Repo.Migrations.UpdateEvent do
+  use Ecto.Migration
+
+  def change do
+    alter table("events") do
+      add :shoot_time, :string
+      add :shoot_location, :string
+      add :edit_image_deadline, :utc_datetime
+      add :gallery_link, :string
+      add :blog_link, :string
+      add :wedding_location, :string
+      add :reception_location, :string
+      add :coordinator_name, :string
+      add :notes, :text
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -23,6 +23,9 @@ alias FocalApi.Repo
 {:ok, date, _} = DateTime.from_iso8601("2020-04-17T14:00:00Z")
 date = date |> DateTime.truncate(:second)
 
+{:ok, date2, _} = DateTime.from_iso8601("2020-08-17T14:00:00Z")
+date2 = date2 |> DateTime.truncate(:second)
+
 francesca = Accounts.get_user_by_email("littlegangwolf@gmail.com")
 
 # Francesca Client 1
@@ -82,10 +85,39 @@ francesca_client_event = %Event{
   shoot_date: date,
   uuid: Ecto.UUID.generate(),
   client_id: francesca_client.id,
-  package_id: francesca_client_package.id
+  package_id: francesca_client_package.id,
+  shoot_time: "6AM - 11AM",
+  shoot_location: "Los Angeles Poppy Fields",
+  edit_image_deadline: date,
+  gallery_link: "http://google.com",
+  blog_link: "http://google.com",
+  wedding_location: nil,
+  reception_location: nil,
+  coordinator_name: nil,
+  notes: "Have clients bring extra flowers and a see through chair.",
 }
 Repo.insert!(francesca_client_event)
 francesca_client_event = Repo.get_by(Event, uuid: francesca_client_event.uuid)
+
+francesca_client_event_3 = %Event{
+  event_name: "Wedding",
+  shoot_date: date2,
+  uuid: Ecto.UUID.generate(),
+  client_id: francesca_client.id,
+  package_id: francesca_client_package.id,
+  shoot_time: "8AM - 11PM",
+  shoot_location: nil,
+  edit_image_deadline: date2,
+  gallery_link: "http://google.com",
+  blog_link: "http://google.com",
+  wedding_location: "Viviana Church in DTLA",
+  reception_location: "Redbird DTLA",
+  coordinator_name: nil,
+  notes: nil,
+}
+Repo.insert!(francesca_client_event_3)
+francesca_client_event_3 = Repo.get_by(Event, uuid: francesca_client_event_3.uuid)
+
 
 francesca_client_task = %Task{
   category: "New Client Inquiry",
@@ -152,7 +184,16 @@ francesca_client_event2 = %Event{
   shoot_date: date,
   uuid: Ecto.UUID.generate(),
   client_id: francesca_client2.id,
-  package_id: francesca_client_package2.id
+  package_id: francesca_client_package2.id,
+  shoot_time: "6AM - 12PM",
+  shoot_location: "Los Angeles Poppy Fields",
+  edit_image_deadline: date,
+  gallery_link: "http://google.com",
+  blog_link: "http://google.com",
+  wedding_location: nil,
+  reception_location: nil,
+  coordinator_name: nil,
+  notes: "Have clients bring extra flowers and a see through chair.",
 }
 Repo.insert!(francesca_client_event2)
 francesca_client_event2 = Repo.get_by(Event, uuid: francesca_client_event2.uuid)

--- a/test/focal_api/clients_test.exs
+++ b/test/focal_api/clients_test.exs
@@ -119,6 +119,18 @@ defmodule FocalApi.ClientsTest do
       assert Clients.get_package_by_uuid!(package.uuid) == package
     end
 
+    test "get_earliest_shoot_date_by_package/1 returns earliest shoot date for a set of package events" do
+      package = package_fixture()
+      {:ok, date1, _} = DateTime.from_iso8601("2010-04-17T14:00:00Z")
+      {:ok, date2, _} = DateTime.from_iso8601("2008-09-17T14:00:00Z")
+      {:ok, date3, _} = DateTime.from_iso8601("2010-01-17T14:00:00Z")
+      TestHelpers.event_fixture(%{ package_id: package.id, shoot_date: date1 })
+      TestHelpers.event_fixture(%{ package_id: package.id, shoot_date: date2 })
+      TestHelpers.event_fixture(%{ package_id: package.id, shoot_date: date3 })
+
+      assert Clients.get_earliest_shoot_date_by_package(package.uuid) == date2
+    end
+
     test "create_package/1 with valid data creates a package" do
       assert {:ok, %Package{} = package} = Clients.create_package(@valid_attrs)
       assert package.package_name == "some package_name"

--- a/test/focal_api_web/controllers/event_controller_test.exs
+++ b/test/focal_api_web/controllers/event_controller_test.exs
@@ -72,6 +72,7 @@ defmodule FocalApiWeb.EventControllerTest do
                "uuid" => uuid,
                "client_uuid" => package_client_uuid,
                "package_uuid" => package_uuid,
+               "shoot_location" => shoot_location
              } = json_response(conn, 200)["data"]
     end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -110,15 +110,24 @@ defmodule FocalApi.TestHelpers do
   def event_fixture(attrs \\ %{}) do
     client = client_fixture()
     package = package_fixture(%{ client_id: client.id })
-
+    {:ok, date1, _} = DateTime.from_iso8601("2010-04-17T14:00:00Z")
     params =
       attrs
       |> Enum.into(%{
         event_name: "some event_name",
-        shoot_date: "2010-04-17T14:00:00Z",
+        shoot_date: date1,
         uuid: Ecto.UUID.generate(),
         client_id: client.id,
-        package_id: package.id
+        package_id: package.id,
+        shoot_time: "6AM - 11AM",
+        shoot_location: "Los Angeles Poppy Fields",
+        edit_image_deadline: date1,
+        gallery_link: "http://google.com",
+        blog_link: "http://google.com",
+        wedding_location: nil,
+        reception_location: nil,
+        coordinator_name: nil,
+        notes: "Have clients bring extra flowers and a see through chair.",
       })
 
     {:ok, event} =


### PR DESCRIPTION
- Event currently holds all information for default event fields and special fields for wedding related events.

This is the current simplest option to complete the story, but may need to be refactored in the future to figure out how to compose a BaseEvent schema that feeds a Event and WeddingEvent schema and how to make it seem like the same event type in the eyes of Package.