### PR TITLE
Update event controller to return index of package events

### DIFF
--- a/lib/focal_api/clients.ex
+++ b/lib/focal_api/clients.ex
@@ -91,7 +91,7 @@ defmodule FocalApi.Clients do
 
   def list_events_by_package(package_uuid) do
     package = get_package_by_uuid!(package_uuid)
-    query = from event in Event, where: ^package.id == event.package_id
+    query = from event in Event, where: ^package.id == event.package_id, order_by: event.event_name
     Repo.all(query, preload: [:package])
   end
 

--- a/lib/focal_api_web/controllers/event_controller.ex
+++ b/lib/focal_api_web/controllers/event_controller.ex
@@ -28,10 +28,14 @@ defmodule FocalApiWeb.EventController do
     |> Map.put_new("uuid", Ecto.UUID.generate)
 
     with {:ok, %Event{} = event} <- Clients.create_event(create_attrs) do
+      package = Clients.get_package!(event.package_id)
+      events = Clients.list_events_by_package(package.uuid)
+
       conn
       |> put_status(:created)
-      |> put_resp_header("location", Routes.event_path(conn, :show, event))
-      |> render("show.json", event: event)
+      |> put_resp_header("location", Routes.event_path(conn, :index_by_package, package.uuid))
+
+      render(conn, "index.json", events: events)
     end
   end
 
@@ -47,7 +51,9 @@ defmodule FocalApiWeb.EventController do
     |> Map.put("uuid", event.uuid)
 
     with {:ok, %Event{} = event} <- Clients.update_event(event, update_attrs) do
-      render(conn, "show.json", event: event)
+      package = Clients.get_package!(event.package_id)
+      events = Clients.list_events_by_package(package.uuid)
+      render(conn, "index.json", events: events)
     end
   end
 
@@ -55,7 +61,9 @@ defmodule FocalApiWeb.EventController do
     event = Clients.get_event_by_uuid!(event_uuid)
 
     with {:ok, %Event{}} <- Clients.delete_event(event) do
-      send_resp(conn, :no_content, "")
+      package = Clients.get_package!(event.package_id)
+      events = Clients.list_events_by_package(package.uuid)
+      render(conn, "index.json", events: events)
     end
   end
 

--- a/test/focal_api_web/controllers/event_controller_test.exs
+++ b/test/focal_api_web/controllers/event_controller_test.exs
@@ -62,7 +62,7 @@ defmodule FocalApiWeb.EventControllerTest do
       |> TestHelpers.valid_session(client.user)
       |> post(Routes.event_path(conn, :create, package.uuid), @create_attrs)
 
-      assert %{"uuid" => uuid} = json_response(conn, 201)["data"]
+      assert [%{"uuid" => uuid}] = json_response(conn, 200)["data"]
 
       conn = get(conn, Routes.event_path(conn, :show, uuid))
 
@@ -118,7 +118,7 @@ defmodule FocalApiWeb.EventControllerTest do
       |> TestHelpers.valid_session(client.user)
       |> put(Routes.event_path(conn, :update, uuid), @update_attrs)
 
-      assert %{"uuid" => ^uuid} = json_response(conn, 200)["data"]
+      assert [%{"uuid" => ^uuid}] = json_response(conn, 200)["data"]
 
       conn = get(conn, Routes.event_path(conn, :show, uuid))
 
@@ -174,7 +174,7 @@ defmodule FocalApiWeb.EventControllerTest do
       |> TestHelpers.valid_session(client.user)
       |> delete(Routes.event_path(conn, :delete, event.uuid))
 
-      assert response(conn, 204)
+      assert response(conn, 200)
 
       assert_error_sent 404, fn ->
         get(conn, Routes.event_path(conn, :show, event.uuid))


### PR DESCRIPTION
- Update create, update and delete to return an index of package events after the controller action completes. This is for the frontend to reset state