### PR TITLE
Update Task to accept a order value

### DIFF
--- a/lib/focal_api/clients.ex
+++ b/lib/focal_api/clients.ex
@@ -143,13 +143,13 @@ defmodule FocalApi.Clients do
 
   def list_tasks_by_event(event_uuid) do
     event = get_event_by_uuid!(event_uuid)
-    query = from task in Task, where: ^event.id == task.event_id
+    query = from task in Task, where: ^event.id == task.event_id, order_by: task.order
     Repo.all(query, preload: [:event])
   end
 
   def list_tasks_by_client(client_uuid) do
     client = get_client_by_uuid!(client_uuid)
-    query = from task in Task, where: ^client.id == task.client_id
+    query = from task in Task, where: ^client.id == task.client_id, order_by: task.order
     Repo.all(query, preload: [:client])
   end
 
@@ -157,7 +157,7 @@ defmodule FocalApi.Clients do
     client = get_client_by_uuid!(client_uuid)
     query = from task in Task,
               where: ^client.id == task.client_id and task.is_completed == false,
-              order_by: task.inserted_at,
+              order_by: task.order,
               limit: 1
     Repo.all(query, preload: [:client])
   end
@@ -165,16 +165,22 @@ defmodule FocalApi.Clients do
   def list_incomplete_tasks_by_workflow(workflow_uuid) do
     workflow = get_workflow_by_uuid!(workflow_uuid) |> Repo.preload(:task)
     query = from task in Task,
-              where: ^workflow.id == task.workflow_id and task.is_completed == false,
-              order_by: task.inserted_at
+              where: ^workflow.id == task.workflow_id and task.is_completed == false
     Repo.all(query, preload: [:workflow])
   end
 
   def list_completed_tasks_by_workflow(workflow_uuid) do
     workflow = get_workflow_by_uuid!(workflow_uuid) |> Repo.preload(:task)
     query = from task in Task,
-              where: ^workflow.id == task.workflow_id and task.is_completed == true,
-              order_by: task.inserted_at
+              where: ^workflow.id == task.workflow_id and task.is_completed == true
+    Repo.all(query, preload: [:workflow])
+  end
+
+  def list_tasks_by_workflow(workflow_uuid) do
+    workflow = get_workflow_by_uuid!(workflow_uuid) |> Repo.preload(:task)
+    query = from task in Task,
+              where: ^workflow.id == task.workflow_id,
+              order_by: task.order
     Repo.all(query, preload: [:workflow])
   end
 

--- a/lib/focal_api/clients/task.ex
+++ b/lib/focal_api/clients/task.ex
@@ -9,7 +9,7 @@ defmodule FocalApi.Clients.Task do
     field :category, :string
     field :is_completed, :boolean, default: false
     field :step, :string
-
+    field :order, :integer
     field :uuid, Ecto.UUID
     belongs_to :event, Event
     belongs_to :client, Client
@@ -21,7 +21,7 @@ defmodule FocalApi.Clients.Task do
   @doc false
   def changeset(task, attrs) do
     task
-    |> cast(attrs, [:uuid, :category, :step, :is_completed, :event_id, :client_id, :workflow_id])
+    |> cast(attrs, [:uuid, :category, :step, :is_completed, :event_id, :client_id, :workflow_id, :order])
     |> validate_required([:uuid, :category, :step, :is_completed])
   end
 end

--- a/lib/focal_api/default_tasks.ex
+++ b/lib/focal_api/default_tasks.ex
@@ -2,55 +2,55 @@ defmodule FocalApi.DefaultTasks do
 
   def new_client_inquiry_tasks() do
     [
-      %{ step: "Request More Information" },
-      %{ step: "Save Client Information" },
+      %{ step: "Request More Information", order: 0 },
+      %{ step: "Save Client Information", order: 1 },
     ]
   end
 
   def proposal_and_retainer_tasks() do
     [
-      %{ step: "Send Proposal" },
-      %{ step: "Commit To Proposal" },
-      %{ step: "Receive Signed Proposal & Retainer" },
-      %{ step: "Receive Retainer Fee" },
+      %{ step: "Send Proposal", order: 100 },
+      %{ step: "Commit To Proposal", order: 101 },
+      %{ step: "Receive Signed Proposal & Retainer", order: 102 },
+      %{ step: "Receive Retainer Fee", order: 103 },
     ]
   end
 
   def engagement_tasks() do
     [
-      %{ step: "Schedule Shoot Date" },
-      %{ step: "Send 3 Week Pre Shoot Reminder" },
-      %{ step: "Send 1 Week Pre Shoot Reminder" },
-      %{ step: "Complete Shoot" },
-      %{ step: "Send Thank You Email to Client" },
-      %{ step: "Edit Engagement Images" },
-      %{ step: "Share Gallery Link" },
-      %{ step: "Create & Share Blog" },
+      %{ step: "Schedule Shoot Date", order: 200 },
+      %{ step: "Send 3 Week Pre Shoot Reminder", order: 201 },
+      %{ step: "Send 1 Week Pre Shoot Reminder", order: 202 },
+      %{ step: "Complete Shoot", order: 203 },
+      %{ step: "Send Thank You Email to Client", order: 204 },
+      %{ step: "Edit Engagement Images", order: 205 },
+      %{ step: "Share Gallery Link", order: 206 },
+      %{ step: "Create & Share Blog", order: 207 },
     ]
   end
 
   def wedding_tasks() do
     [
-      %{ step: "Schedule Shoot Date" },
-      %{ step: "Send 4 Week Pre-Shoot Final Invoice" },
-      %{ step: "Send 4 Week Pre Shoot Reminder" },
-      %{ step: "Receive Remaining Balance" },
-      %{ step: "Send 1 Week Pre Shoot Reminder" },
-      %{ step: "Complete Shoot" },
-      %{ step: "Send Thank You Email to Client" },
-      %{ step: "Edit Wedding Images" },
-      %{ step: "Share Gallery Link" },
-      %{ step: "Create & Share Blog" },
+      %{ step: "Schedule Shoot Date", order: 300 },
+      %{ step: "Send 4 Week Pre-Shoot Final Invoice", order: 301 },
+      %{ step: "Send 4 Week Pre Shoot Reminder", order: 302 },
+      %{ step: "Receive Remaining Balance", order: 303 },
+      %{ step: "Send 1 Week Pre Shoot Reminder", order: 304 },
+      %{ step: "Complete Shoot", order: 305 },
+      %{ step: "Send Thank You Email to Client", order: 306 },
+      %{ step: "Edit Wedding Images", order: 307 },
+      %{ step: "Share Gallery Link", order: 308 },
+      %{ step: "Create & Share Blog", order: 309 },
     ]
   end
 
   def closeout_tasks() do
     [
-      %{ step: "Request Feedback" },
-      %{ step: "Save & Share Feedback" },
-      %{ step: "Send Out Package Deliverables" },
-      %{ step: "Send Out Gallery Link to Vendors" },
-      %{ step: "Send Out 1 Year Anniversary Email" },
+      %{ step: "Request Feedback", order: 400 },
+      %{ step: "Save & Share Feedback", order: 401 },
+      %{ step: "Send Out Package Deliverables", order: 402 },
+      %{ step: "Send Out Gallery Link to Vendors", order: 403 },
+      %{ step: "Send Out 1 Year Anniversary Email", order: 404 },
     ]
   end
 

--- a/lib/focal_api/default_workflows.ex
+++ b/lib/focal_api/default_workflows.ex
@@ -82,7 +82,8 @@ defmodule FocalApi.DefaultWorkflows do
         workflow_id: workflow_id,
         category: category_name,
         step: task.step,
-        is_completed: false
+        is_completed: false,
+        order: task.order
       })
     end)
     |> handle_results()

--- a/lib/focal_api_web/controllers/client_controller.ex
+++ b/lib/focal_api_web/controllers/client_controller.ex
@@ -70,7 +70,9 @@ defmodule FocalApiWeb.ClientController do
     client = Clients.get_client_by_uuid!(client_uuid)
 
     with {:ok, %Client{}} <- Clients.delete_client(client) do
-      send_resp(conn, :no_content, "")
+      conn
+      |> put_view(FocalApiWeb.DefaultView)
+      |> render("show.json", value: "Ok")
     end
   end
 

--- a/lib/focal_api_web/controllers/session_controller.ex
+++ b/lib/focal_api_web/controllers/session_controller.ex
@@ -28,7 +28,8 @@ defmodule FocalApiWeb.SessionController do
   def delete(conn, _params) do
     conn
     |> configure_session(drop: true)
-    |> Plug.Conn.send_resp(201, "No Content")
+    |> put_view(FocalApiWeb.DefaultView)
+    |> render("show.json", value: "Ok")
   end
 
   defp user_params(auth, provider) do

--- a/lib/focal_api_web/views/default_view.ex
+++ b/lib/focal_api_web/views/default_view.ex
@@ -1,0 +1,8 @@
+defmodule FocalApiWeb.DefaultView do
+  use FocalApiWeb, :view
+
+  def render("show.json", %{value: value}) do
+    %{data: value}
+  end
+
+end

--- a/lib/focal_api_web/views/workflow_view.ex
+++ b/lib/focal_api_web/views/workflow_view.ex
@@ -17,10 +17,11 @@ defmodule FocalApiWeb.WorkflowView do
     workflow = preloaded_workflow(workflow.uuid)
     completed_tasks = Clients.list_completed_tasks_by_workflow(workflow.uuid)
     incomplete_tasks = Clients.list_incomplete_tasks_by_workflow(workflow.uuid)
+    tasks = Clients.list_tasks_by_workflow(workflow.uuid)
     %{
       uuid: workflow.uuid,
       workflow_name: workflow.workflow_name,
-      tasks: render_many(workflow.task, TaskView, "task.json"),
+      tasks: render_many(tasks, TaskView, "task.json"),
       completed_tasks: length(completed_tasks),
       incomplete_tasks: length(incomplete_tasks),
       order: workflow.order

--- a/priv/repo/migrations/20190912221844_create_packages.exs
+++ b/priv/repo/migrations/20190912221844_create_packages.exs
@@ -5,7 +5,7 @@ defmodule FocalApi.Repo.Migrations.CreatePackages do
     create table(:packages) do
       add :package_name, :string
       add :uuid, :uuid
-      add :client_id, references(:clients)
+      add :client_id, references(:clients, on_delete: :delete_all)
 
       timestamps()
     end

--- a/priv/repo/migrations/20190913002847_create_events.exs
+++ b/priv/repo/migrations/20190913002847_create_events.exs
@@ -6,8 +6,8 @@ defmodule FocalApi.Repo.Migrations.CreateEvents do
       add :event_name, :string
       add :shoot_date, :utc_datetime
       add :uuid, :uuid
-      add :client_id, references(:clients)
-      add :package_id, references(:packages)
+      add :client_id, references(:clients, on_delete: :delete_all)
+      add :package_id, references(:packages, on_delete: :delete_all)
 
       timestamps()
     end

--- a/priv/repo/migrations/20190913151337_create_tasks.exs
+++ b/priv/repo/migrations/20190913151337_create_tasks.exs
@@ -7,8 +7,8 @@ defmodule FocalApi.Repo.Migrations.CreateTasks do
       add :category, :text
       add :step, :text
       add :is_completed, :boolean, default: false, null: false
-      add :event_id, references(:events, on_delete: :nothing)
-      add :client_id, references(:clients, on_delete: :nothing)
+      add :event_id, references(:events, on_delete: :delete_all)
+      add :client_id, references(:clients, on_delete: :delete_all)
 
       timestamps()
     end

--- a/priv/repo/migrations/20190923215058_update_task.exs
+++ b/priv/repo/migrations/20190923215058_update_task.exs
@@ -1,0 +1,10 @@
+defmodule FocalApi.Repo.Migrations.UpdateTask do
+  use Ecto.Migration
+
+  def change do
+    alter table("tasks") do
+      add :order, :integer
+    end
+
+  end
+end

--- a/test/focal_api/clients_test.exs
+++ b/test/focal_api/clients_test.exs
@@ -317,6 +317,18 @@ defmodule FocalApi.ClientsTest do
       assert Clients.list_completed_tasks_by_workflow(workflow.uuid) == [task1, task3]
     end
 
+    test "list_tasks_by_workflow/1 returns tasks by workflow, in order" do
+      workflow = TestHelpers.workflow_fixture()
+
+      task1 = TestHelpers.task_fixture(%{ workflow_id: workflow.id, is_completed: true, order: 1 })
+      task2 = TestHelpers.task_fixture(%{ workflow_id: workflow.id, is_completed: false, order: 0 })
+      task3 = TestHelpers.task_fixture(%{ workflow_id: workflow.id, is_completed: true, order: 4 })
+      task4 = TestHelpers.task_fixture(%{ workflow_id: workflow.id, is_completed: true, order: 3 })
+      task5 = TestHelpers.task_fixture(%{ workflow_id: workflow.id, is_completed: false, order: 2 })
+
+      assert Clients.list_tasks_by_workflow(workflow.uuid) == [task2, task1, task5, task4, task3]
+    end
+
     test "get_task!/1 returns the task with given id" do
       task = task_fixture()
       assert Clients.get_task!(task.id) == task

--- a/test/focal_api_web/controllers/client_controller_test.exs
+++ b/test/focal_api_web/controllers/client_controller_test.exs
@@ -324,7 +324,7 @@ defmodule FocalApiWeb.ClientControllerTest do
       |> TestHelpers.valid_session(client.user)
       |> delete(Routes.client_path(conn, :delete, client.uuid))
 
-      assert response(conn, 204)
+      assert response(conn, 200)
 
       assert_error_sent 404, fn ->
         get(conn, Routes.client_path(conn, :show, client.uuid))

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -152,7 +152,8 @@ defmodule FocalApi.TestHelpers do
         uuid: Ecto.UUID.generate(),
         client_id: client.id,
         event_id: event.id,
-        workflow_id: workflow.id
+        workflow_id: workflow.id,
+        order: 0
       })
 
     {:ok, task} =


### PR DESCRIPTION
- Task now accepts an order number, so that they will always be retrieved in the exact order specified.
- Create DefaultView for delete and logout. It was previously sending only a string, but the frontend is now reliant on the `{ data: { data: value } }` pattern for api responses. DefaultView will accept any value and inject it into the data structure pattern the frontend expects
- Update references (package, events, workflow, tasks) to delete_all when client is deleted.